### PR TITLE
embed links for installing dependencies

### DIFF
--- a/docs/contribute/source/os/windows.md
+++ b/docs/contribute/source/os/windows.md
@@ -17,8 +17,8 @@ cd WasmEdge
 
 WasmEdge requires LLVM 13 and you may need to install these following dependencies by yourself.
 
-- Chocolatey, we use it to install `cmake`, `ninja`, and `vswhere`.
-- Windows SDK 19041
+- [Chocolatey](https://chocolatey.org/install), we use it to install `cmake`, `ninja`, and `vswhere`.
+- [Windows SDK 19041](https://blogs.windows.com/windowsdeveloper/2020/05/12/start-developing-on-windows-10-version-2004-today/)
 - LLVM 13.0.1, you can find the pre-built files [here](https://github.com/WasmEdge/llvm-windows/releases) or you can just follow the `instructions/commands` to download automatically.
 
 ```powershell


### PR DESCRIPTION
I embedded links to the installation instructions for the required dependencies, in order to make them easier to install.

## What type of PR is this

documentation

