### PR TITLE
[Feat] - Added Ignored Paths to Deploy CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,7 @@ on:
       - 'README.md'
       - 'LICENSE'
       - 'CODE_OF_CONDUCT.md'
+      - 'CONTRIBUTING.md'
       - '.vscode/**'
       - '.husky/**'
       - '.env'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,17 @@
-name: CI
-on: [push]
+name: Deploy CI
+on:
+  workflow_trigger:
+  push:
+    paths-ignore:
+      - 'README.md'
+      - 'LICENSE'
+      - 'CODE_OF_CONDUCT.md'
+      - '.vscode/**'
+      - '.husky/**'
+      - '.env'
+      - '.gitignore'
+    branches:
+      - main
 
 jobs:
   publish:
@@ -27,14 +39,7 @@ jobs:
 
       - name: Build
         run: npm run build
-#      - name: Change Name
-#        run: |
-#          mv build en
-#          mkdir build
-#          mv en build/en
-#          cd build/en
-#          mv zh ../zh
-#          mv zh-TW ../zh-TW
+
       - name: Push directory to another repository
         if: ${{ github.event_name == 'push' }}
         uses: cpina/github-action-push-to-another-repository@main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,6 @@
 name: Deploy CI
 on:
-  workflow_trigger:
+  workflow_dispatch:
   push:
     paths-ignore:
       - 'README.md'


### PR DESCRIPTION
**Description:**

- This PR updates the deploy CI to ignore changes to the below-mentioned files
    - 'README.md'
    - 'LICENSE'
    - 'CODE_OF_CONDUCT.md'
    - '.vscode/**'
    - '.husky/**'
    - '.env'
    - '.gitignore'

If files apart from the above ones change, then the CI will be triggered.

- This PR also adds a workflow_dispatch trigger in case the deploy fails and the maintainers/admins want to trigger it manually
