### PR TITLE
[Chore] - Remove GC Proposal

### DIFF
--- a/docs/develop/wasmedge/extensions/proposals.md
+++ b/docs/develop/wasmedge/extensions/proposals.md
@@ -56,10 +56,6 @@ WasmEdge implements the following [WASI proposals](https://github.com/WebAssembl
 | [Machine Learning (wasi-nn)][] | `x86_64 Linux`, OpenVINO (since `0.10.1`), PyTorch (since `0.11.1`), and TensorFlow-Lite (since `0.11.2`) backends |
 | [proxy-wasm][] | `x86_64 Linux (Interpreter only)` (since `0.8.2`) |
 
-The following proposals is under development and may be supported in the future:
-
-- WebAssembly GC Proposal
-
 [Sockets]: https://github.com/WebAssembly/wasi-sockets
 [Crypto]: https://github.com/WebAssembly/wasi-crypto
 [Machine Learning (wasi-nn)]: https://github.com/WebAssembly/wasi-nn


### PR DESCRIPTION
## Explanation

This PR removes the WebAssembly GC proposal from the WASI proposal section.

## Related issue

fixes #104 

## What type of PR is this

Documentation
