### PR TITLE
[Feat] - Removed `zh-tw` locale

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -27,7 +27,7 @@ const config = {
     // to replace "en" with "zh-Hans".
     i18n: {
         defaultLocale: 'en',
-        locales: ['en', 'zh', 'zh-TW'],
+        locales: ['en', 'zh'],
         localeConfigs: {
             en: {
                 label: 'English'


### PR DESCRIPTION
**Description:**

This PR removes `zh-tw` locale from docusaurus config