### PR TITLE
[Doc] Update the introduction to `WasmEdge Rust SDK`

### DIFF
--- a/docs/contribute/source/plugin/wasi_nn.md
+++ b/docs/contribute/source/plugin/wasi_nn.md
@@ -81,7 +81,7 @@ cmake --install build
 If the built `wasmedge` CLI tool cannot find the WASI-NN plug-in, you can set the `WASMEDGE_PLUGIN_PATH` environment variable to the plug-in installation path (such as `/usr/local/lib/wasmedge/`, or the built plug-in path `build/plugins/wasi_nn/`) to try to fix this issue.
 :::
 
-Then you will have an executable `wasmedge` runtime under `/usr/local/bin` and the WASI-NN with OpenVINO backend plug-in under `/usr/local/lib/wasmedge/libwasmedgePluginWasiNN.so` after installation.
+Then you will have an executable `wasmedge` runtime under `/usr/local/bin` and the WASI-NN with PyTorch backend plug-in under `/usr/local/lib/wasmedge/libwasmedgePluginWasiNN.so` after installation.
 
 ## Build WasmEdge with WASI-NN TensorFlow-Lite Backend
 
@@ -100,7 +100,7 @@ cmake --install build
 If the built `wasmedge` CLI tool cannot find the WASI-NN plug-in, you can set the `WASMEDGE_PLUGIN_PATH` environment variable to the plug-in installation path (such as `/usr/local/lib/wasmedge/`, or the built plug-in path `build/plugins/wasi_nn/`) to try to fix this issue.
 :::
 
-Then you will have an executable `wasmedge` runtime under `/usr/local/bin` and the WASI-NN with OpenVINO backend plug-in under `/usr/local/lib/wasmedge/libwasmedgePluginWasiNN.so` after installation.
+Then you will have an executable `wasmedge` runtime under `/usr/local/bin` and the WASI-NN with TensorFlow-lite backend plug-in under `/usr/local/lib/wasmedge/libwasmedgePluginWasiNN.so` after installation.
 
 Installing the necessary `libtensorflowlite_c.so` and `libtensorflowlite_flex.so` on both `Ubuntu 20.04` and `manylinux2014` for the backend, we recommend the following commands:
 

--- a/docs/embed/rust/intro.md
+++ b/docs/embed/rust/intro.md
@@ -24,22 +24,22 @@ WasmEdge Rust SDK consists of five crates:
 
   Since this crate depends on the WasmEdge C API, it needs to be installed in your system first. Please refer to [WasmEdge Installation and Uninstallation](../../start/install.md) to install the WasmEdge library. The versioning table below shows the version of the WasmEdge library required by each version of the `wasmedge-sdk` crate.
 
-  | wasmedge-sdk  | WasmEdge lib  | wasmedge-sys  | wasmedge-types| wasmedge-macro| async-wasi|
-  | :-----------: | :-----------: | :-----------: | :-----------: | :-----------: | :-------: |
-  | 0.11.0        | 0.13.3        | 0.16.0        | 0.4.3         | 0.6.0         | 0.0.3     |
-  | 0.10.1        | 0.13.3        | 0.15.1        | 0.4.2         | 0.5.0         | 0.0.2     |
-  | 0.10.0        | 0.13.2        | 0.15.0        | 0.4.2         | 0.5.0         | 0.0.2     |
-  | 0.9.0         | 0.13.1        | 0.14.0        | 0.4.2         | 0.4.0         | 0.0.1     |
-  | 0.9.0         | 0.13.0        | 0.14.0        | 0.4.2         | 0.4.0         | 0.0.1     |
-  | 0.8.1         | 0.12.1        | 0.13.1        | 0.4.1         | 0.3.0         | -         |
-  | 0.8.0         | 0.12.0        | 0.13.0        | 0.4.1         | 0.3.0         | -         |
-  | 0.7.1         | 0.11.2        | 0.12.2        | 0.3.1         | 0.3.0         | -         |
-  | 0.7.0         | 0.11.2        | 0.12          | 0.3.1         | 0.3.0         | -         |
-  | 0.6.0         | 0.11.2        | 0.11          | 0.3.0         | 0.2.0         | -         |
-  | 0.5.0         | 0.11.1        | 0.10          | 0.3.0         | 0.1.0         | -         |
-  | 0.4.0         | 0.11.0        | 0.9           | 0.2.1         | -             | -         |
-  | 0.3.0         | 0.10.1        | 0.8           | 0.2           | -             | -         |
-  | 0.1.0         | 0.10.0        | 0.7           | 0.1           | -             | -         |
+  | wasmedge-sdk | WasmEdge lib | wasmedge-sys | wasmedge-types | wasmedge-macro | async-wasi |
+  | :-: | :-: | :-: | :-: | :-: | :-: |
+  | 0.11.0 | 0.13.3 | 0.16.0 | 0.4.3 | 0.6.0 | 0.0.3 |
+  | 0.10.1 | 0.13.3 | 0.15.1 | 0.4.2 | 0.5.0 | 0.0.2 |
+  | 0.10.0 | 0.13.2 | 0.15.0 | 0.4.2 | 0.5.0 | 0.0.2 |
+  | 0.9.0 | 0.13.1 | 0.14.0 | 0.4.2 | 0.4.0 | 0.0.1 |
+  | 0.9.0 | 0.13.0 | 0.14.0 | 0.4.2 | 0.4.0 | 0.0.1 |
+  | 0.8.1 | 0.12.1 | 0.13.1 | 0.4.1 | 0.3.0 | - |
+  | 0.8.0 | 0.12.0 | 0.13.0 | 0.4.1 | 0.3.0 | - |
+  | 0.7.1 | 0.11.2 | 0.12.2 | 0.3.1 | 0.3.0 | - |
+  | 0.7.0 | 0.11.2 | 0.12 | 0.3.1 | 0.3.0 | - |
+  | 0.6.0 | 0.11.2 | 0.11 | 0.3.0 | 0.2.0 | - |
+  | 0.5.0 | 0.11.1 | 0.10 | 0.3.0 | 0.1.0 | - |
+  | 0.4.0 | 0.11.0 | 0.9 | 0.2.1 | - | - |
+  | 0.3.0 | 0.10.1 | 0.8 | 0.2 | - | - |
+  | 0.1.0 | 0.10.0 | 0.7 | 0.1 | - | - |
 
   WasmEdge Rust SDK can automatically search the following paths for the WasmEdge library:
 

--- a/docs/embed/rust/intro.md
+++ b/docs/embed/rust/intro.md
@@ -24,18 +24,22 @@ WasmEdge Rust SDK consists of five crates:
 
   Since this crate depends on the WasmEdge C API, it needs to be installed in your system first. Please refer to [WasmEdge Installation and Uninstallation](../../start/install.md) to install the WasmEdge library. The versioning table below shows the version of the WasmEdge library required by each version of the `wasmedge-sdk` crate.
 
-  | wasmedge-sdk | WasmEdge lib | wasmedge-sys | wasmedge-types | wasmedge-macro | async-wasi |
-  | :-: | :-: | :-: | :-: | :-: | :-: |
-  | 0.9.0 | 0.13.0 | 0.14.0 | 0.4.2 | 0.4.0 | 0.0.1 |
-  | 0.8.1 | 0.12.1 | 0.13.1 | 0.4.1 | 0.3.0 | - |
-  | 0.8.0 | 0.12.0 | 0.13.0 | 0.4.1 | 0.3.0 | - |
-  | 0.7.1 | 0.11.2 | 0.12.2 | 0.3.1 | 0.3.0 | - |
-  | 0.7.0 | 0.11.2 | 0.12 | 0.3.1 | 0.3.0 | - |
-  | 0.6.0 | 0.11.2 | 0.11 | 0.3.0 | 0.2.0 | - |
-  | 0.5.0 | 0.11.1 | 0.10 | 0.3.0 | 0.1.0 | - |
-  | 0.4.0 | 0.11.0 | 0.9 | 0.2.1 | - | - |
-  | 0.3.0 | 0.10.1 | 0.8 | 0.2 | - | - |
-  | 0.1.0 | 0.10.0 | 0.7 | 0.1 | - | - |
+  | wasmedge-sdk  | WasmEdge lib  | wasmedge-sys  | wasmedge-types| wasmedge-macro| async-wasi|
+  | :-----------: | :-----------: | :-----------: | :-----------: | :-----------: | :-------: |
+  | 0.11.0        | 0.13.3        | 0.16.0        | 0.4.3         | 0.6.0         | 0.0.3     |
+  | 0.10.1        | 0.13.3        | 0.15.1        | 0.4.2         | 0.5.0         | 0.0.2     |
+  | 0.10.0        | 0.13.2        | 0.15.0        | 0.4.2         | 0.5.0         | 0.0.2     |
+  | 0.9.0         | 0.13.1        | 0.14.0        | 0.4.2         | 0.4.0         | 0.0.1     |
+  | 0.9.0         | 0.13.0        | 0.14.0        | 0.4.2         | 0.4.0         | 0.0.1     |
+  | 0.8.1         | 0.12.1        | 0.13.1        | 0.4.1         | 0.3.0         | -         |
+  | 0.8.0         | 0.12.0        | 0.13.0        | 0.4.1         | 0.3.0         | -         |
+  | 0.7.1         | 0.11.2        | 0.12.2        | 0.3.1         | 0.3.0         | -         |
+  | 0.7.0         | 0.11.2        | 0.12          | 0.3.1         | 0.3.0         | -         |
+  | 0.6.0         | 0.11.2        | 0.11          | 0.3.0         | 0.2.0         | -         |
+  | 0.5.0         | 0.11.1        | 0.10          | 0.3.0         | 0.1.0         | -         |
+  | 0.4.0         | 0.11.0        | 0.9           | 0.2.1         | -             | -         |
+  | 0.3.0         | 0.10.1        | 0.8           | 0.2           | -             | -         |
+  | 0.1.0         | 0.10.0        | 0.7           | 0.1           | -             | -         |
 
   WasmEdge Rust SDK can automatically search the following paths for the WasmEdge library:
 
@@ -44,10 +48,10 @@ WasmEdge Rust SDK consists of five crates:
 
     Note that if you have installed the WasmEdge library in a different path, you can set the `WASMEDGE_INCLUDE_DIR` and `WASMEDGE_LIB_DIR` environment variables to the path of the WasmEdge library.
 
-- Add `wasmedge-sdk` crate to your `Cargo.toml` file. Note that, according to the versioning table, the version of `wasmedge-sdk` matching `WasmEdge v0.13.0` is `0.9.0`.
+- Add `wasmedge-sdk` crate to your `Cargo.toml` file. Note that, according to the versioning table, the version of `wasmedge-sdk` matching `WasmEdge v0.13.3` is `0.11.0`.
 
   ```toml
-  wasmedge-sdk = "0.9.0"
+  wasmedge-sdk = "0.11.0"
   ```
 
 **Notice:** The minimum supported Rust version is 1.68.


### PR DESCRIPTION
## Explanation

Update the content of the `WasmEdge Rust SDK` section to the latest release `0.11.0`

## Related issue

NA

## What type of PR is this

documentation

## Proposed Changes

The latest version of `WasmEdge Rust SDK` has been released. The `intro.md` file should be updated with the info about the latest release.
