### PR TITLE
fixed->issue:147 search bar missing, reason:themes:[ Array ] in confi…

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -60,6 +60,7 @@ const config = {
     ],
 
     themes: [
+        '@docusaurus/theme-mermaid',
         [
             "@easyops-cn/docusaurus-search-local",
             /** @type {import("@easyops-cn/docusaurus-search-local").PluginOptions} */
@@ -218,8 +219,6 @@ const extendedConfig = {
     ...config,
     markdown: {
         mermaid: true,
-    },
-    themes: ['@docusaurus/theme-mermaid'],
-};
-
+    },    
+}
 module.exports = extendedConfig;

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -219,6 +219,6 @@ const extendedConfig = {
     ...config,
     markdown: {
         mermaid: true,
-    },    
+    }    
 }
 module.exports = extendedConfig;


### PR DESCRIPTION
fixed->issue:147 search bar missing, reason:themes:[ Array ] in config consisting of localsearch is over written by themes [Array] in extendedConfig

## Explanation

**All the changes are done in  docusaurus.config.js**

The reason for the search bar is not visible the, themes array [line no 62] in the config object which again consist a array of "@easyops-cn/docusaurus-search-local" the extension which is responsible for the search bar, is being overwritten by the array in extendedConfig object.


## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`, `fixes #1234`.
-->
[fixes#147](https://github.com/WasmEdge/docs/issues/147)

## What type of PR is this

/fixes 
/feature-required

## Proposed Changes

Merge the themes array present in the extendedConfig object which overwrites the themes array present in config object.

## Live link for testing
[Live Testing Link](https://rakesh-docs.netlify.app/)

## ScreenShot
![Screenshot from 2023-08-18 09-58-41](https://github.com/WasmEdge/docs/assets/55751461/4048533c-b379-49e1-b35a-e22ace23a51c)
