### PR TITLE
Remove Prettier

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,5 +37,5 @@ jobs:
       - name: Lint
         run: npm run lint:ci
 
-      - name: Prettier Code
-        run: npm run format:diff
+      # - name: Prettier Code
+      #   run: npm run format:diff


### PR DESCRIPTION
## Explanation

The `prettier` command in CI gives extremely unhelpfully error messages. It simply asks me to run `prettier` without telling me what the actual "style issue" is. 

**I would NOT permit `prettier` to make changes to my writing in any way without first knowing what it thinks the problem is.**

Plus, we already have lint. I think we should remove prettier.
