### PR TITLE
Correct wrong example code

### DIFF
--- a/docs/contribute/plugin/develop_plugin_cpp.md
+++ b/docs/contribute/plugin/develop_plugin_cpp.md
@@ -62,7 +62,7 @@ To create a plug-in with host functions and modules, follow these steps:
   ```cpp
   #pragma once
 
-  #include "plug-in/plug-in.h"
+  #include "plugin/plugin.h"
 
   #include <cstdint>
   #include <string>
@@ -228,9 +228,6 @@ To build the plug-in shared library, developers should build in CMake with the W
   ```cmake
   wasmedge_add_library(wasmedgePluginTest
     SHARED
-    env.cpp
-    func.cpp
-    module.cpp
     testplugin.cpp
   )
 


### PR DESCRIPTION
## Explanation

The example code in `testplugin.h` and `test/CMakeLists.txt` of this section is wrong. The tutorial becomes confusing because of that. I corrected it and now this version can be compiled.

## What type of PR is this

> /kind documentation

## Proposed Changes

In testplugin.h

```cpp
// #include "plug-in/plug-in.h"
#include "plugin/plugin.h"
```

in cmakelists.txt. There is no `env.cpp, module.cpp, func.cpp` in this tutorial, so it is confusing.

```
wasmedge_add_library(wasmedgePluginTest
  SHARED
  testplugin.cpp
)
```
