### PR TITLE
Fixed broken github link (fibonacci.wasm)

### DIFF
--- a/docs/embed/c/intro.md
+++ b/docs/embed/c/intro.md
@@ -55,7 +55,7 @@ Get result: 3524578
 
 ## Quick Start Guide for the WasmEdge AOT compiler
 
-Assume that the WASM file [fibonacci.wasm](https://github.com/WasmEdge/WasmEdge/raw/master/examples/wasm/fibonacci.wasm) is copied into the current directory, and the C file `test_wasmedge_compiler.c` is as follows:
+Assume that the WASM file [fibonacci.wasm](https://github.com/WasmEdge/WasmEdge/raw/master/examples/wasm/fibonacci.wasm) is copied into the current directory, and the C file `test_wasmedge_compiler.c` is as follows :
 
 ```c
 #include <wasmedge/wasmedge.h>

--- a/docs/start/install.md
+++ b/docs/start/install.md
@@ -128,15 +128,15 @@ WasmEdge uses plug-ins to extend its functionality. If you want to use more of W
 The WasmEdge TLS plug-in utilizes the native OpenSSL library to support HTTPS and TLS requests from WasmEdge sockets. To install the WasmEdge TLS plug-in on Linux, run the following commands after you have installed WasmEdge.
 
 ```bash
-wget https://github.com/second-state/wasmedge_rustls_plugin/releases/download/0.2.0/wasmedge_rustls_plugin_ubuntu-20.04.zip
-unzip wasmedge_rustls_plugin_ubuntu-20.04.zip
+wget https://github.com/WasmEdge/WasmEdge/releases/download/0.13.4/WasmEdge-plugin-wasmedge_rustls-0.13.4-manylinux2014_x86_64.tar.gz
+tar xf WasmEdge-plugin-wasmedge_rustls-0.13.4-manylinux2014_x86_64.tar.gz
 
 # If you only installed WasmEdge for the local user
-cp target/release/libwasmedge_rustls.so ~/.wasmedge/plugin/
+cp libwasmedge_rustls.so ~/.wasmedge/plugin/
 
 # If you installed Wasmedge at /usr/local for all users
 sudo mkdir -p /usr/local/lib/wasmedge/
-sudo cp target/release/libwasmedge_rustls.so /usr/local/lib/wasmedge/
+sudo cp libwasmedge_rustls.so /usr/local/lib/wasmedge/
 ```
 
 Then, go to [HTTPS request in Rust chapter](../develop/rust/http_service/client.md) to see how to run HTTPs services with Rust.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/embed/c/intro.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/embed/c/intro.md
@@ -10,7 +10,7 @@ The WasmEdge C API is also the fundamental API for other languages' SDK.
 
 ## Quick Start Guide for the WasmEdge Runner
 
-The following is an example of running a WASM file. Assume that the WASM file [fibonacci.wasm](https://github.com/WasmEdge/WasmEdge/raw/master/examples/wasm/fibonacci.wasm) is copied into the current directory, and the C file `test_wasmedge.c` is as follows:
+The following is an example of running a WASM file. Assume that the WASM file [fibonacci.wasm](https://github.com/WasmEdge/WasmEdge/tree/master/examples/wasm) is copied into the current directory, and the C file `test_wasmedge.c` is as follows:
 
 ```c
 #include <wasmedge/wasmedge.h>

--- a/i18n/zh/docusaurus-plugin-content-docs/current/embed/c/intro.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/embed/c/intro.md
@@ -10,7 +10,7 @@ The WasmEdge C API is also the fundamental API for other languages' SDK.
 
 ## Quick Start Guide for the WasmEdge Runner
 
-The following is an example of running a WASM file. Assume that the WASM file [fibonacci.wasm](https://github.com/WasmEdge/WasmEdge/tree/master/examples/wasm) is copied into the current directory, and the C file `test_wasmedge.c` is as follows:
+The following is an example of running a WASM file. Assume that the WASM file [fibonacci.wasm](https://github.com/WasmEdge/WasmEdge/blob/master/examples/wasm/fibonacci.wat) is copied into the current directory, and the C file `test_wasmedge.c` is as follows:
 
 ```c
 #include <wasmedge/wasmedge.h>

--- a/i18n/zh/docusaurus-plugin-content-docs/current/start/install.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/start/install.md
@@ -128,15 +128,15 @@ WasmEdge uses plug-ins to extend its functionality. If you want to use more of W
 The WasmEdge TLS plug-in utilizes the native OpenSSL library to support HTTPS and TLS requests from WasmEdge sockets. To install the WasmEdge TLS plug-in on Linux, run the following commands after you have installed WasmEdge.
 
 ```bash
-wget https://github.com/second-state/wasmedge_rustls_plugin/releases/download/0.2.0/wasmedge_rustls_plugin_ubuntu-20.04.zip
-unzip wasmedge_rustls_plugin_ubuntu-20.04.zip
+wget https://github.com/WasmEdge/WasmEdge/releases/download/0.13.4/WasmEdge-plugin-wasmedge_rustls-0.13.4-manylinux2014_x86_64.tar.gz
+tar xf WasmEdge-plugin-wasmedge_rustls-0.13.4-manylinux2014_x86_64.tar.gz
 
 # If you only installed WasmEdge for the local user
-cp target/release/libwasmedge_rustls.so ~/.wasmedge/plugin/
+cp libwasmedge_rustls.so ~/.wasmedge/plugin/
 
 # If you installed Wasmedge at /usr/local for all users
 sudo mkdir -p /usr/local/lib/wasmedge/
-sudo cp target/release/libwasmedge_rustls.so /usr/local/lib/wasmedge/
+sudo cp libwasmedge_rustls.so /usr/local/lib/wasmedge/
 ```
 
 Then, go to [HTTPS request in Rust chapter](../develop/rust/http_service/client.md) to see how to run HTTPs services with Rust.


### PR DESCRIPTION
## Explanation

In the documentation, the fibonacci.wasm file link leads to 404 page since, Now the directory contains .wat files.

