### PR TITLE
Update the installation description for `wasmedge_rustls_plugin`

### DIFF
--- a/docs/start/install.md
+++ b/docs/start/install.md
@@ -136,7 +136,7 @@ cp libwasmedge_rustls.so ~/.wasmedge/plugin/
 
 # If you installed Wasmedge at /usr/local for all users
 sudo mkdir -p /usr/local/lib/wasmedge/
-sudo cp libwasmedge_rustls /usr/local/lib/wasmedge/
+sudo cp libwasmedge_rustls.so /usr/local/lib/wasmedge/
 ```
 
 Then, go to [HTTPS request in Rust chapter](../develop/rust/http_service/client.md) to see how to run HTTPs services with Rust.

--- a/docs/start/install.md
+++ b/docs/start/install.md
@@ -128,15 +128,15 @@ WasmEdge uses plug-ins to extend its functionality. If you want to use more of W
 The WasmEdge TLS plug-in utilizes the native OpenSSL library to support HTTPS and TLS requests from WasmEdge sockets. To install the WasmEdge TLS plug-in on Linux, run the following commands after you have installed WasmEdge.
 
 ```bash
-wget https://github.com/second-state/wasmedge_rustls_plugin/releases/download/0.2.0/wasmedge_rustls_plugin_ubuntu-20.04.zip
-unzip wasmedge_rustls_plugin_ubuntu-20.04.zip
+wget https://github.com/WasmEdge/WasmEdge/releases/download/0.13.4/WasmEdge-plugin-wasmedge_rustls-0.13.4-manylinux2014_x86_64.tar.gz
+tar xf WasmEdge-plugin-wasmedge_rustls-0.13.4-manylinux2014_x86_64.tar.gz
 
 # If you only installed WasmEdge for the local user
-cp target/release/libwasmedge_rustls.so ~/.wasmedge/plugin/
+cp libwasmedge_rustls.so ~/.wasmedge/plugin/
 
 # If you installed Wasmedge at /usr/local for all users
 sudo mkdir -p /usr/local/lib/wasmedge/
-sudo cp target/release/libwasmedge_rustls.so /usr/local/lib/wasmedge/
+sudo cp libwasmedge_rustls /usr/local/lib/wasmedge/
 ```
 
 Then, go to [HTTPS request in Rust chapter](../develop/rust/http_service/client.md) to see how to run HTTPs services with Rust.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/start/install.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/start/install.md
@@ -136,7 +136,7 @@ cp libwasmedge_rustls.so ~/.wasmedge/plugin/
 
 # If you installed Wasmedge at /usr/local for all users
 sudo mkdir -p /usr/local/lib/wasmedge/
-sudo cp libwasmedge_rustls /usr/local/lib/wasmedge/
+sudo cp libwasmedge_rustls.so /usr/local/lib/wasmedge/
 ```
 
 Then, go to [HTTPS request in Rust chapter](../develop/rust/http_service/client.md) to see how to run HTTPs services with Rust.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/start/install.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/start/install.md
@@ -128,15 +128,15 @@ WasmEdge uses plug-ins to extend its functionality. If you want to use more of W
 The WasmEdge TLS plug-in utilizes the native OpenSSL library to support HTTPS and TLS requests from WasmEdge sockets. To install the WasmEdge TLS plug-in on Linux, run the following commands after you have installed WasmEdge.
 
 ```bash
-wget https://github.com/second-state/wasmedge_rustls_plugin/releases/download/0.2.0/wasmedge_rustls_plugin_ubuntu-20.04.zip
-unzip wasmedge_rustls_plugin_ubuntu-20.04.zip
+wget https://github.com/WasmEdge/WasmEdge/releases/download/0.13.4/WasmEdge-plugin-wasmedge_rustls-0.13.4-manylinux2014_x86_64.tar.gz
+tar xf WasmEdge-plugin-wasmedge_rustls-0.13.4-manylinux2014_x86_64.tar.gz
 
 # If you only installed WasmEdge for the local user
-cp target/release/libwasmedge_rustls.so ~/.wasmedge/plugin/
+cp libwasmedge_rustls.so ~/.wasmedge/plugin/
 
 # If you installed Wasmedge at /usr/local for all users
 sudo mkdir -p /usr/local/lib/wasmedge/
-sudo cp target/release/libwasmedge_rustls.so /usr/local/lib/wasmedge/
+sudo cp libwasmedge_rustls /usr/local/lib/wasmedge/
 ```
 
 Then, go to [HTTPS request in Rust chapter](../develop/rust/http_service/client.md) to see how to run HTTPs services with Rust.


### PR DESCRIPTION
## Explanation

Starting with WasmEdge v0.13.4, the `wasmedge_rustls_plugin` has been bundled within the WasmEdge core (ref: https://github.com/WasmEdge/WasmEdge/releases/tag/0.13.4). Therefore, this patch modifies the installation instructions for rustls_plugin to indicate that it should be retrieved from the `WasmEdge/WasmEdge` repository, rather than from the `second-state/wasmedge_rustls_plugin`.

## Related issue

This might be related to #108

## What type of PR is this

> /kind documentation
