### PR TITLE
[DOCS]Added missing crun instructions

### DIFF
--- a/docs/develop/deploy/podman.md
+++ b/docs/develop/deploy/podman.md
@@ -45,11 +45,13 @@ That's it.
    Next, configure and build a `crun` binary with WasmEdge support.
 
    ```bash
+   git clone https://github.com/containers/crun
+   cd crun
    ./autogen.sh
    ./configure --with-wasmedge
    make
    sudo make install
-   # replace crun (be careful, you may want to do a bakup first)
+   # replace crun (be careful, you may want to do a backup first)
    mv crun $(which crun)
    ```
 


### PR DESCRIPTION
## Explanation

Step 3 of https://wasmedge.org/docs/develop/deploy/podman/#prerequisites: It seems like some instructions are missing.

Build and configure crun with WasmEdge support

Next, configure and build a crun binary with WasmEdge support.

Maybe there should be a git clone, similar to https://wasmedge.org/docs/develop/deploy/oci-runtime/crun/#prerequisites


## Related issue

Fixes #195 
Fixes https://github.com/WasmEdge/WasmEdge/issues/3028

## What type of PR is this

/kind documentation


## Proposed Changes

Adds the missing git clone in step 3 of https://wasmedge.org/docs/develop/deploy/podman/#prerequisites
Also fixed a typo
