### PR TITLE
Update develop_plugin_c.md

### DIFF
--- a/docs/contribute/plugin/develop_plugin_c.md
+++ b/docs/contribute/plugin/develop_plugin_c.md
@@ -186,6 +186,12 @@ WasmEdge_Result HostFuncSub(void *Data,
       /* Pointer to the plug-in option description array (Work in progress). */
       .ProgramOptions = NULL,
   }};
+
+  /* Export the plug-in descriptor */
+  WASMEDGE_CAPI_PLUGIN_EXPORT const WasmEdge_PluginDescriptor *
+  WasmEdge_Plugin_GetDescriptor(void) {
+    return &Desc;
+  }
   ```
 
   These descriptions define the name, description, version, and creation function of the plug-in and the name and description of the module it contains.


### PR DESCRIPTION
## Explanation

Make the code example for developing plugins in C complete. Now one can copy all the code snippets and expect it to work.

## Related issue

Closes Wasmedge/Wasmedge#3122
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`, `fixes #1234`.
-->

## What type of PR is this

> /kind documentation

## Proposed Changes

Copied the missing part of [testplugin.c](https://github.com/WasmEdge/WasmEdge/blob/64d6bbd6198aef097ebf5fd95b3c444e431bbf9e/test/plugins/unittest/testplugin.c) into the document
