### PR TITLE
Update the source for building crun

### DIFF
--- a/docs/start/build-and-run/docker_wasm_gpu.md
+++ b/docs/start/build-and-run/docker_wasm_gpu.md
@@ -76,12 +76,12 @@ GPU 0: NVIDIA GeForce GTX 1080 (UUID: GPU-********-****-****-****-************)
 
 ## Setup your container runtime (crun + wasmedge + plugin system)
 
-Build crun with wasmedge  and plugin system both enable 
+Build crun with wasmedge enable
 
 ```bash
 > sudo apt install -y make git gcc build-essential pkgconf libtool libsystemd-dev libprotobuf-c-dev libcap-dev libseccomp-dev libyajl-dev go-md2man libtool autoconf python3 automake
 
-> git clone -b enable-wasmedge-plugin https://github.com/second-state/crun
+> git clone https://github.com/containers/crun
 > cd crun
 > ./autogen.sh
 > ./configure --with-wasmedge
@@ -96,7 +96,7 @@ Replace container run time
 {
   "runtimes": {
     "crun": {
-      "path": "<the crun binary path build from you>"
+      "path": "<The crun binary path is built by yourself>"
     }
   },
   "features": {

--- a/docs/start/build-and-run/podman_wasm_gpu.md
+++ b/docs/start/build-and-run/podman_wasm_gpu.md
@@ -57,12 +57,12 @@ nvidia.com/gpu=all
 
 ## Setup your container runtime (crun + wasmedge + plugin system)
 
-Build crun with wasmedge  and plugin system both enable 
+Build crun with wasmedge enable
 
 ```bash
 > sudo apt install -y make git gcc build-essential pkgconf libtool libsystemd-dev libprotobuf-c-dev libcap-dev libseccomp-dev libyajl-dev go-md2man libtool autoconf python3 automake
 
-> git clone -b enable-wasmedge-plugin https://github.com/second-state/crun
+> git clone https://github.com/containers/crun
 > cd crun
 > ./autogen.sh
 > ./configure --with-wasmedge


### PR DESCRIPTION
The nnpreload and plugin loading mechanisms are already in the upstream.

## Explanation

Replace demo crun source.

## Related issue

https://github.com/WasmEdge/WasmEdge/issues/3217

## What type of PR is this

Documentation

## Proposed Changes

Update repo link
