### PR TITLE
fix some docs

### DIFF
--- a/docs/contribute/source/plugin/wasi_nn.md
+++ b/docs/contribute/source/plugin/wasi_nn.md
@@ -277,23 +277,6 @@ cmake --build build
 cmake --install build
 ```
 
-#### Apple Silicon Model
-
-You can build and install WasmEdge from source directly on the macOS arm64 platform. It will use the built-in GPU by default.
-
-```bash
-cd <path/to/your/wasmedge/source/folder>
-# Enable METAL on arm64 macOS.
-cmake -GNinja -Bbuild -DCMAKE_BUILD_TYPE=Release \
-  -DWASMEDGE_PLUGIN_WASI_NN_BACKEND="GGML" \
-  -DWASMEDGE_PLUGIN_WASI_NN_GGML_LLAMA_METAL=ON \
-  -DWASMEDGE_PLUGIN_WASI_NN_GGML_LLAMA_BLAS=OFF \
-  .
-cmake --build build
-# For the WASI-NN plugin, you should install this project.
-cmake --install build
-```
-
 ### Appendix
 
 <!-- prettier-ignore -->

--- a/docs/contribute/source/plugin/wasi_nn.md
+++ b/docs/contribute/source/plugin/wasi_nn.md
@@ -294,6 +294,30 @@ cmake --build build
 cmake --install build
 ```
 
+### Appendix
+
+<!-- prettier-ignore -->
+:::note
+If the built `wasmedge` CLI tool cannot find the WASI-NN plugin, you can set the `WASMEDGE_PLUGIN_PATH` environment variable to the plugin installation path (such as `/usr/local/lib/wasmedge/` or the built plugin path `build/plugins/wasi_nn/`) to try to fix this issue.
+:::
+
+<!-- prettier-ignore -->
+:::note
+We also provided the pre-built ggml plugins on the following platforms:
+
+- darwin\_x86\_64: Intel Model macOS
+- darwin\_arm64: Apple Silicon Model macOS
+- ubuntu20.04\_x86\_64: x86\_64 Linux (the glibc is using Ubuntu20.04 one)
+- ubuntu20.04\_aarch64: aarch64 Linux (the glibc is using Ubuntu20.04 one)
+- ubuntu20.04\_blas\_x86\_64: x86\_64 Linux with OpenBLAS support (the glibc is using Ubuntu20.04 one)
+- ubuntu20.04\_blas\_aarch64: aarch64 Linux with OpenBLAS support (the glibc is using Ubuntu20.04 one)
+- ubuntu20.04\_cuda\_x86\_64: x86\_64 Linux with CUDA 12 support (the glibc is using Ubuntu20.04 one)
+- ubuntu20.04\_cuda\_aarch64: aarch64 Linux with CUDA 11 support (the glibc is using Ubuntu20.04 one), for NVIDIA Jetson AGX Orin
+- manylinux2014\_x86\_64: x86\_64 Linux (the glibc is using CentOS 7 one)
+- manylinux2014\_aarch64: aarch64 Linux (the glibc is using CentOS 7 one)
+
+:::
+
 ## Build WasmEdge with WASI-NN Neural Speed Backend
 
 The Neural Speed backend relies on Neural Speed, we recommend the following commands to install Neural Speed.
@@ -320,27 +344,3 @@ cmake --install build
 ```
 
 Then you will have an executable `wasmedge` runtime under `/usr/local/bin` and the WASI-NN with Neural Speed backend plug-in under `/usr/local/lib/wasmedge/libwasmedgePluginWasiNN.so` after installation.
-
-### Appendix
-
-<!-- prettier-ignore -->
-:::note
-If the built `wasmedge` CLI tool cannot find the WASI-NN plugin, you can set the `WASMEDGE_PLUGIN_PATH` environment variable to the plugin installation path (such as `/usr/local/lib/wasmedge/` or the built plugin path `build/plugins/wasi_nn/`) to try to fix this issue.
-:::
-
-<!-- prettier-ignore -->
-:::note
-We also provided the pre-built ggml plugins on the following platforms:
-
-- darwin\_x86\_64: Intel Model macOS
-- darwin\_arm64: Apple Silicon Model macOS
-- ubuntu20.04\_x86\_64: x86\_64 Linux (the glibc is using Ubuntu20.04 one)
-- ubuntu20.04\_aarch64: aarch64 Linux (the glibc is using Ubuntu20.04 one)
-- ubuntu20.04\_blas\_x86\_64: x86\_64 Linux with OpenBLAS support (the glibc is using Ubuntu20.04 one)
-- ubuntu20.04\_blas\_aarch64: aarch64 Linux with OpenBLAS support (the glibc is using Ubuntu20.04 one)
-- ubuntu20.04\_cuda\_x86\_64: x86\_64 Linux with CUDA 12 support (the glibc is using Ubuntu20.04 one)
-- ubuntu20.04\_cuda\_aarch64: aarch64 Linux with CUDA 11 support (the glibc is using Ubuntu20.04 one), for NVIDIA Jetson AGX Orin
-- manylinux2014\_x86\_64: x86\_64 Linux (the glibc is using CentOS 7 one)
-- manylinux2014\_aarch64: aarch64 Linux (the glibc is using CentOS 7 one)
-
-:::

--- a/docs/start/install.md
+++ b/docs/start/install.md
@@ -56,7 +56,7 @@ WasmEdge plug-ins are pre-built native modules that provide additional functiona
 curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- --plugins wasi_nn-ggml
 ```
 
-To install multiple plug-ins, you can pass a list of plug-ins with the `--plugins` option. For example, the following command installs the `wasi_logging`` and the `wasi_nn-ggml` plug-ins. The `wasi_logging` plug-in allows the Rust [log::Log](https://crates.io/crates/log) API to compile into Wasm and run in WasmEdge.
+To install multiple plug-ins, you can pass a list of plug-ins with the `--plugins` option. For example, the following command installs the `wasi_logging` and the `wasi_nn-ggml` plug-ins. The `wasi_logging` plug-in allows the Rust [log::Log](https://crates.io/crates/log) API to compile into Wasm and run in WasmEdge.
 
 ```bash
 curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- --plugins wasi_logging wasi_nn-ggml


### PR DESCRIPTION
I fixed some docs:

- docs/contribute/source/plugin/wasi_nn.md
  - fix misplaced Appendix part for ggml backend
    - I think the cause is https://github.com/WasmEdge/docs/commit/a2dd6ee153563c8b326d707628aef960e8d26ba1 put the `Build WasmEdge with WASI-NN Neural Speed Backend` part in the wrong place.
  - remove duplicate Apple Silicon Model part for ggml backend
    - The original has two identical `Apple Silicon Model` parts. One is in the MacOS section after `Intel Model` part and the other is in the Linux section after `General Linux without any acceleration framework` part.
    I removed the one in the Linux section after `General Linux without any acceleration framework` part.
    - I think this duplicate was removed in [26c0689](https://github.com/WasmEdge/docs/commit/26c068984bbbbec9f67eab5ff741e7b800e995a4?diff=split&w=0#diff-df3f0ad65faf64eda1c5955ff0452c0c379fd53323ea14e809c344c00df8588eL280-L296) and wrongly added again in [a2dd6ee](https://github.com/WasmEdge/docs/commit/a2dd6ee153563c8b326d707628aef960e8d26ba1?diff=split&w=0#diff-df3f0ad65faf64eda1c5955ff0452c0c379fd53323ea14e809c344c00df8588eR280-R296).
- docs/start/install.md
  - remove extra backtick