### PR TITLE
misc: Add CODEOWNER for automatically assigning the reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Global rule:
+# General Owner:
+*               @hydai @juntao @alabulei1


### PR DESCRIPTION
## Explanation

I would like to add the CODEOWNER file so the GitHub will automatically assign the reviewers for the docs PRs.

## Related issue

None.