### PR TITLE
Update the new rust compiler target for wasm

### DIFF
--- a/docs/contribute/source/os/android/cli.md
+++ b/docs/contribute/source/os/android/cli.md
@@ -74,17 +74,17 @@ git clone https://github.com/second-state/wasm-learning.git
 cd wasm-learning/rust/birds_v1
 ```
 
-Use the `cargo` command to build a WASM bytecode file from the Rust source code. The WASM file is located at `target/wasm32-wasi/release/birds_v1.wasm`.
+Use the `cargo` command to build a WASM bytecode file from the Rust source code. The WASM file is located at `target/wasm32-wasip1/release/birds_v1.wasm`.
 
 ```bash
-rustup target add wasm32-wasi
-cargo build --release --target=wasm32-wasi
+rustup target add wasm32-wasip1
+cargo build --release --target=wasm32-wasip1
 ```
 
 Push the WASM bytecode file, tensorflow lite model file, and the test bird picture file onto the Android device using `adb`.
 
 ```bash
-adb push target/wasm32-wasi/release/birds_v1.wasm /data/local/tmp/WasmEdge-tensorflow-tools
+adb push target/wasm32-wasip1/release/birds_v1.wasm /data/local/tmp/WasmEdge-tensorflow-tools
 adb push lite-model_aiy_vision_classifier_birds_V1_3.tflite /data/local/tmp/WasmEdge-tensorflow-tools
 adb push bird.jpg /data/local/tmp/WasmEdge-tensorflow-tools
 ```

--- a/docs/develop/c/simd.md
+++ b/docs/develop/c/simd.md
@@ -6,9 +6,9 @@ sidebar_position: 4
 
 [128-bit packed Single Instruction Multiple Data (SIMD)](https://webassembly.github.io/simd/core/syntax/instructions.html#simd-instructions) instructions provide simultaneous computations over packed data in just one instruction. It's commonly used to improve performance for multimedia applications. With the SIMD proposal, the modules can benefit from using these commonly used instructions in modern hardware to gain more speedup.
 
-If you are interested in enabling the SIMD proposal will improve how much performance of the applications, please refer to our [wasm32-wasi benchmark](https://github.com/second-state/wasm32-wasi-benchmark) for more information. The Mandelbrot Set application can have a **2.65x** speedup in our benchmark.
+If you are interested in enabling the SIMD proposal will improve how much performance of the applications, please refer to our [wasm32-wasip1 benchmark](https://github.com/second-state/wasm32-wasi-benchmark) for more information. The Mandelbrot Set application can have a **2.65x** speedup in our benchmark.
 
-We modified the Mandelbrot Set example from our [wasm32-wasi benchmark project](https://github.com/second-state/wasm32-wasi-benchmark/blob/master/src/mandelbrot.c). We will use this as an example in this article.
+We modified the Mandelbrot Set example from our [wasm32-wasip1 benchmark project](https://github.com/second-state/wasm32-wasi-benchmark/blob/master/src/mandelbrot.c). We will use this as an example in this article.
 
 ## Prerequisites
 

--- a/docs/develop/javascript/hello_world.md
+++ b/docs/develop/javascript/hello_world.md
@@ -76,7 +76,7 @@ git clone https://github.com/second-state/wasmedge-quickjs
 cd wasmedge-quickjs
 
 # Build the QuickJS JavaScript interpreter
-cargo build --target wasm32-wasi --release
+cargo build --target wasm32-wasip1 --release
 ```
 
 The WebAssembly-based JavaScript interpreter program is located in the build `target` directory.
@@ -84,7 +84,7 @@ The WebAssembly-based JavaScript interpreter program is located in the build `ta
 WasmEdge provides a `wasmedgec` utility to compile and add a native machine code section to the `wasm` file. You can use `wasmedge` to run the natively instrumented `wasm` file to get a much faster performance.
 
 ```bash
-wasmedge compile target/wasm32-wasi/release/wasmedge_quickjs.wasm wasmedge_quickjs.wasm
+wasmedge compile target/wasm32-wasip1/release/wasmedge_quickjs.wasm wasmedge_quickjs.wasm
 wasmedge --dir .:. wasmedge_quickjs.wasm example_js/hello.js
 ```
 

--- a/docs/develop/javascript/rust.md
+++ b/docs/develop/javascript/rust.md
@@ -22,8 +22,8 @@ The examples are in the `examples/embed_js` folder in the `wasmedge-quickjs` rep
 
 ```bash
 cd examples/embed_js
-cargo build --target wasm32-wasi --release
-wasmedge --dir .:. target/wasm32-wasi/release/embed_js.wasm
+cargo build --target wasm32-wasip1 --release
+wasmedge --dir .:. target/wasm32-wasip1/release/embed_js.wasm
 ```
 
 ## Code explanation: embed JavaScript into a Rust program
@@ -191,8 +191,8 @@ The project is in the [examples/embed_rust_module](https://github.com/second-sta
 
 ```bash
 cd examples/embed_rust_module
-cargo build --target wasm32-wasi --release
-wasmedge --dir .:. target/wasm32-wasi/release/embed_rust_module.wasm
+cargo build --target wasm32-wasip1 --release
+wasmedge --dir .:. target/wasm32-wasip1/release/embed_rust_module.wasm
 ```
 
 ### Code explanation

--- a/docs/develop/javascript/tensorflow.md
+++ b/docs/develop/javascript/tensorflow.md
@@ -103,7 +103,7 @@ git clone https://github.com/second-state/wasmedge-quickjs
 cd wasmedge-quickjs
 
 # Build the QuickJS JavaScript interpreter with WASI NN
-cargo build --target wasm32-wasi --release --features=wasi_nn
+cargo build --target wasm32-wasip1 --release --features=wasi_nn
 ```
 
 The WebAssembly-based JavaScript interpreter program is located in the build `target` directory.
@@ -111,5 +111,5 @@ The WebAssembly-based JavaScript interpreter program is located in the build `ta
 WasmEdge provides a `wasmedge compile` utility to compile and add a native machine code section to the wasm file. You can use wasmedge to run the natively instrumented wasm file to get much faster performance.
 
 ```bash
-wasmedge compile target/wasm32-wasi/release/wasmedge_quickjs.wasm wasmedge_quickjs_nn.wasm
+wasmedge compile target/wasm32-wasip1/release/wasmedge_quickjs.wasm wasmedge_quickjs_nn.wasm
 ```

--- a/docs/develop/python/hello_world.md
+++ b/docs/develop/python/hello_world.md
@@ -8,10 +8,10 @@ Several different language implementations of the Python runtime exist, and some
 
 ## Compile RustPython
 
-To compile RustPython, you should install the Rust toolchain on your machine. And `wasm32-wasi` platform support should be enabled.
+To compile RustPython, you should install the Rust toolchain on your machine. And `wasm32-wasip1` platform support should be enabled.
 
 ```bash
-rustup target add wasm32-wasi
+rustup target add wasm32-wasip1
 ```
 
 Then you could use the following command to clone and compile RustPython:
@@ -19,23 +19,23 @@ Then you could use the following command to clone and compile RustPython:
 ```bash
 git clone https://github.com/RustPython/RustPython.git
 cd RustPython
-cargo build --release --target wasm32-wasi --features="freeze-stdlib"
+cargo build --release --target wasm32-wasip1 --features="freeze-stdlib"
 ```
 
-`freeze-stdlib` feature is enabled for including Python standard library inside the binary file. The output file should be at `target/wasm32-wasi/release/rustpython.wasm`.
+`freeze-stdlib` feature is enabled for including Python standard library inside the binary file. The output file should be at `target/wasm32-wasip1/release/rustpython.wasm`.
 
 ## AOT Compile
 
 WasmEdge supports compiling WebAssembly bytecode programs into native machine code for better performance. It is highly recommended to compile the RustPython to native machine code before running.
 
 ```bash
-wasmedge compile ./target/wasm32-wasi/release/rustpython.wasm ./target/wasm32-wasi/release/rustpython.wasm
+wasmedge compile ./target/wasm32-wasip1/release/rustpython.wasm ./target/wasm32-wasip1/release/rustpython.wasm
 ```
 
 ## Run
 
 ```bash
-wasmedge ./target/wasm32-wasi/release/rustpython.wasm
+wasmedge ./target/wasm32-wasip1/release/rustpython.wasm
 ```
 
 Then you could get a Python shell in WebAssembly!
@@ -45,5 +45,5 @@ Then you could get a Python shell in WebAssembly!
 You can pre-open directories to let WASI programs have permission to read and write files stored on the real machine. The following command mounted the current working directory to the WASI virtual file system.
 
 ```bash
-wasmedge --dir .:. ./target/wasm32-wasi/release/rustpython.wasm
+wasmedge --dir .:. ./target/wasm32-wasip1/release/rustpython.wasm
 ```

--- a/docs/develop/rust/dapr.md
+++ b/docs/develop/rust/dapr.md
@@ -59,8 +59,8 @@ Build.
 
 ```bash
 cd image-api-grayscale
-cargo build --target wasm32-wasi --release
-wasmedgec ./target/wasm32-wasi/release/image-api-grayscale.wasm image-api-grayscale.wasm
+cargo build --target wasm32-wasip1 --release
+wasmedgec ./target/wasm32-wasip1/release/image-api-grayscale.wasm image-api-grayscale.wasm
 ```
 
 Deploy.
@@ -81,8 +81,8 @@ Build.
 
 ```bash
 cd image-api-classify
-cargo build --target wasm32-wasi --release
-wasmedgec target/wasm32-wasi/release/wasmedge_hyper_server_tflite.wasm wasmedge_hyper_server_tflite.wasm
+cargo build --target wasm32-wasip1 --release
+wasmedgec target/wasm32-wasip1/release/wasmedge_hyper_server_tflite.wasm wasmedge_hyper_server_tflite.wasm
 ```
 
 Deploy.
@@ -103,8 +103,8 @@ Build.
 
 ```bash
 cd events-service
-cargo build --target wasm32-wasi --release
-wasmedgec target/wasm32-wasi/release/events_service.wasm events_service.wasm
+cargo build --target wasm32-wasip1 --release
+wasmedgec target/wasm32-wasip1/release/events_service.wasm events_service.wasm
 ```
 
 Deploy.

--- a/docs/develop/rust/database/my_sql_driver.md
+++ b/docs/develop/rust/database/my_sql_driver.md
@@ -21,10 +21,10 @@ git clone https://github.com/WasmEdge/wasmedge-db-examples
 cd wasmedge-db-examples/mysql_async
 
 # Compile the rust code into WASM
-RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasi --release
+RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasip1 --release
 
 # Execute MySQL statements against a MySQL database at mysql://user:passwd@127.0.0.1:3306
-wasmedge --env "DATABASE_URL=mysql://user:passwd@127.0.0.1:3306/mysql" target/wasm32-wasi/release/crud.wasm
+wasmedge --env "DATABASE_URL=mysql://user:passwd@127.0.0.1:3306/mysql" target/wasm32-wasip1/release/crud.wasm
 ```
 
 <!-- prettier-ignore -->

--- a/docs/develop/rust/database/postgres_driver.md
+++ b/docs/develop/rust/database/postgres_driver.md
@@ -21,10 +21,10 @@ git clone https://github.com/WasmEdge/wasmedge-db-examples
 cd wasmedge-db-examples/postgres
 
 # Compile the rust code into WASM
-RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasi --release
+RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasip1 --release
 
 # Execute SQL statements against a PostgreSQL database at postgres://user:passwd@localhost/testdb
-wasmedge --env "DATABASE_URL=postgres://user:passwd@localhost/testdb" target/wasm32-wasi/release/crud.wasm
+wasmedge --env "DATABASE_URL=postgres://user:passwd@localhost/testdb" target/wasm32-wasip1/release/crud.wasm
 ```
 
 ## Configuration

--- a/docs/develop/rust/database/qdrant_driver.md
+++ b/docs/develop/rust/database/qdrant_driver.md
@@ -23,10 +23,10 @@ git clone https://github.com/WasmEdge/wasmedge-db-examples
 cd wasmedge-db-examples/qdrant
 
 # Compile the rust code into WASM
-RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasi --release
+RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasip1 --release
 
 # Perform vector data operations against a Qdrant at http://localhost:6333
-wasmedge target/wasm32-wasi/release/qdrant_examples.wasm
+wasmedge target/wasm32-wasip1/release/qdrant_examples.wasm
 ```
 
 ## Configuration

--- a/docs/develop/rust/database/redis_driver.md
+++ b/docs/develop/rust/database/redis_driver.md
@@ -21,10 +21,10 @@ git clone https://github.com/WasmEdge/wasmedge-db-examples
 cd wasmedge-db-examples/redis
 
 # Compile the rust code into WASM
-RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasi --release
+RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasip1 --release
 
 # Execute Redis command against a Redis instance at redis://localhost/
-wasmedge --env "REDIS_URL=redis://localhost/" target/wasm32-wasi/release/wasmedge-redis-client-examples.wasm
+wasmedge --env "REDIS_URL=redis://localhost/" target/wasm32-wasip1/release/wasmedge-redis-client-examples.wasm
 ```
 
 ## Configuration

--- a/docs/develop/rust/hello_world.md
+++ b/docs/develop/rust/hello_world.md
@@ -20,13 +20,13 @@ fn main() {
 Build the WASM bytecode:
 
 ```bash
-cargo build --target wasm32-wasi --release
+cargo build --target wasm32-wasip1 --release
 ```
 
 We will use the `wasmedge` command to run the program.
 
 ```bash
-wasmedge target/wasm32-wasi/release/hello.wasm
+wasmedge target/wasm32-wasip1/release/hello.wasm
 ```
 
 ## A simple function
@@ -47,7 +47,7 @@ pub fn add(a: i32, b: i32) -> i32 {
 ### Build the WASM bytecode
 
 ```bash
-cargo build --target wasm32-wasi --release
+cargo build --target wasm32-wasip1 --release
 ```
 
 ### Run the application from command line
@@ -55,7 +55,7 @@ cargo build --target wasm32-wasi --release
 We will use `wasmedge` in reactor mode to run the program. We pass the function name and its input parameters as command line arguments.
 
 ```bash
-wasmedge --reactor target/wasm32-wasi/release/add.wasm add 2 2
+wasmedge --reactor target/wasm32-wasip1/release/add.wasm add 2 2
 ```
 
 ## Pass parameters with complex data types

--- a/docs/develop/rust/http_service/client.md
+++ b/docs/develop/rust/http_service/client.md
@@ -31,10 +31,10 @@ git clone https://github.com/WasmEdge/wasmedge_reqwest_demo
 cd wasmedge_reqwest_demo
 
 # Build the Rust code
-RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasi --release
+RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasip1 --release
 # Use the AoT compiler to get better performance
-wasmedge compile target/wasm32-wasi/release/http.wasm http.wasm
-wasmedge compile target/wasm32-wasi/release/https.wasm https.wasm
+wasmedge compile target/wasm32-wasip1/release/http.wasm http.wasm
+wasmedge compile target/wasm32-wasip1/release/https.wasm https.wasm
 
 # Run the HTTP GET and POST examples
 wasmedge http.wasm
@@ -102,9 +102,9 @@ git clone https://github.com/WasmEdge/wasmedge_hyper_demo
 cd wasmedge_hyper_demo/client
 
 # Build the Rust code
-RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasi --release
+RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasip1 --release
 # Use the AoT compiler to get better performance
-wasmedge compile target/wasm32-wasi/release/wasmedge_hyper_client.wasm wasmedge_hyper_client.wasm
+wasmedge compile target/wasm32-wasip1/release/wasmedge_hyper_client.wasm wasmedge_hyper_client.wasm
 
 # Run the example
 wasmedge wasmedge_hyper_client.wasm
@@ -130,8 +130,8 @@ The HTTPS version of the demo is as follows.
 ```bash
 // Build
 cd wasmedge_hyper_demo/client-https
-RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasi --release
-wasmedge compile target/wasm32-wasi/release/wasmedge_hyper_client_https.wasm wasmedge_hyper_client_https.wasm
+RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasip1 --release
+wasmedge compile target/wasm32-wasip1/release/wasmedge_hyper_client_https.wasm wasmedge_hyper_client_https.wasm
 
 // Run
 wasmedge wasmedge_hyper_client_https.wasm

--- a/docs/develop/rust/http_service/server.md
+++ b/docs/develop/rust/http_service/server.md
@@ -27,9 +27,9 @@ git clone https://github.com/WasmEdge/wasmedge_hyper_demo
 cd wasmedge_hyper_demo/server-axum
 
 # Build the Rust code
-RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasi --release
+RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasip1 --release
 # Use the AoT compiler for better performance
-wasmedge compile target/wasm32-wasi/release/wasmedge_axum_server.wasm wasmedge_axum_server.wasm
+wasmedge compile target/wasm32-wasip1/release/wasmedge_axum_server.wasm wasmedge_axum_server.wasm
 
 # Run the example
 wasmedge wasmedge_axum_server.wasm
@@ -103,9 +103,9 @@ git clone https://github.com/WasmEdge/wasmedge_hyper_demo
 cd wasmedge_hyper_demo/server
 
 # Build the Rust code
-RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasi --release
+RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasip1 --release
 # Use the AoT compiler to get better performance
-wasmedge compile target/wasm32-wasi/release/wasmedge_hyper_server.wasm wasmedge_hyper_server.wasm
+wasmedge compile target/wasm32-wasip1/release/wasmedge_hyper_server.wasm wasmedge_hyper_server.wasm
 
 # Run the example
 wasmedge wasmedge_hyper_server.wasm

--- a/docs/develop/rust/os.md
+++ b/docs/develop/rust/os.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # Access OS services
 
-The WASI (WebAssembly Systems Interface) standard is designed to allow WebAssembly applications to access operating system services. The `wasm32-wasi` target in the Rust compiler supports WASI. This section will use [an example project](https://github.com/second-state/rust-examples/tree/main/wasi) to show how to use Rust standard APIs to access operating system services.
+The WASI (WebAssembly Systems Interface) standard is designed to allow WebAssembly applications to access operating system services. The `wasm32-wasip1` target in the Rust compiler supports WASI. This section will use [an example project](https://github.com/second-state/rust-examples/tree/main/wasi) to show how to use Rust standard APIs to access operating system services.
 
 <!-- prettier-ignore -->
 :::note
@@ -13,7 +13,7 @@ Before we start, ensure [you have Rust and WasmEdge installed](setup.md).
 
 ## Random numbers
 
-The WebAssembly VM is a pure software construct. It does not have a hardware entropy source for random numbers. That's why WASI defines a function for WebAssembly programs to call its host operating system to get a random seed. As a Rust developer, you only need to use the popular (de facto standard) `rand` and/or `getrandom` crates. With the `wasm32-wasi` compiler backend, these crates generate the correct WASI calls in the WebAssembly bytecode. The `Cargo.toml` dependencies are as follows.
+The WebAssembly VM is a pure software construct. It does not have a hardware entropy source for random numbers. That's why WASI defines a function for WebAssembly programs to call its host operating system to get a random seed. As a Rust developer, you only need to use the popular (de facto standard) `rand` and/or `getrandom` crates. With the `wasm32-wasip1` compiler backend, these crates generate the correct WASI calls in the WebAssembly bytecode. The `Cargo.toml` dependencies are as follows.
 
 ```toml
 [dependencies]
@@ -117,13 +117,13 @@ fn main() {
 Use the command below to compile [the Rust project](https://github.com/second-state/rust-examples/blob/main/wasi/).
 
 ```bash
-cargo build --target wasm32-wasi --release
+cargo build --target wasm32-wasip1 --release
 ```
 
 To run it in `wasmedge`, do the following. The `--dir` option maps the current directory of the command shell to the file system's current directory inside the WebAssembly app.
 
 ```bash
-$ wasmedge --dir .:. target/wasm32-wasi/release/wasi.wasm
+$ wasmedge --dir .:. target/wasm32-wasip1/release/wasi.wasm
 Random number: -1157533356
 Random bytes: [159, 159, 9, 119, 106, 172, 207, 82, 173, 145, 233, 214, 104, 35, 23, 53, 155, 12, 102, 231, 117, 67, 192, 215, 207, 202, 128, 198, 213, 41, 235, 57, 89, 223, 138, 70, 185, 137, 74, 162, 42, 20, 226, 177, 114, 170, 172, 39, 149, 99, 122, 68, 115, 205, 155, 202, 4, 48, 178, 224, 124, 42, 24, 56, 215, 90, 203, 150, 106, 128, 127, 201, 177, 187, 20, 195, 172, 56, 72, 28, 53, 163, 59, 36, 129, 160, 69, 203, 196, 72, 113, 61, 46, 249, 81, 134, 94, 134, 159, 51, 233, 247, 253, 116, 202, 210, 100, 75, 74, 95, 197, 44, 81, 87, 89, 115, 20, 226, 143, 139, 50, 60, 196, 59, 206, 105, 161, 226]
 Printed from wasi: This is from a main function

--- a/docs/develop/rust/setup.md
+++ b/docs/develop/rust/setup.md
@@ -26,10 +26,10 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 ## Set up the Rust compiler's target
 
-To build a WASM file running in server-side WebAssembly like WasmEdge, we need to add the `wasm32-wasi` target for the Rust compiler after Rust is installed.
+To build a WASM file running in server-side WebAssembly like WasmEdge, we need to add the `wasm32-wasip1` target for the Rust compiler after Rust is installed.
 
 ```bash
-rustup target add wasm32-wasi
+rustup target add wasm32-wasip1
 ```
 
 ## Special notes for networking apps
@@ -40,21 +40,21 @@ WasmEdge supports async networking APIs provided by [Tokio](https://tokio.rs/) a
 need to add a few config flags to help the Rust compiler choose the correct feature branches in the library source code. Here is an example of `cargo build` command for compiling a tokio app to Wasm.
 
 ```bash
-RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasi --release
+RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasip1 --release
 ```
 
 Alternatively, you could add these lines to the `.cargo/config.toml` file.
 
 ```toml
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"
 rustflags = ["--cfg", "wasmedge", "--cfg", "tokio_unstable"]
 ```
 
 Once you have these lines in `.cargo/config.toml`, you can simply use the regular `cargo` command.
 
 ```bash
-cargo build --target wasm32-wasi --release
+cargo build --target wasm32-wasip1 --release
 ```
 
 ### TLS on MacOS

--- a/docs/develop/rust/socket_networking/client.md
+++ b/docs/develop/rust/socket_networking/client.md
@@ -25,9 +25,9 @@ git clone https://github.com/second-state/wasmedge_wasi_socket.git
 cd wasmedge_wasi_socket/http_client/
 
 # Build the Rust Code
-cargo build --target wasm32-wasi --release
+cargo build --target wasm32-wasip1 --release
 # Use the AoT compiler to get better performance
-wasmedge compile target/wasm32-wasi/release/http_client.wasm http_client.wasm
+wasmedge compile target/wasm32-wasip1/release/http_client.wasm http_client.wasm
 
 # Run the example
 wasmedge http_client.wasm
@@ -69,9 +69,9 @@ git clone https://github.com/second-state/wasmedge_wasi_socket
 cd wasmedge_wasi_socket/nonblock_http_client/
 
 # Build the Rust Code
-cargo build --target wasm32-wasi --release
+cargo build --target wasm32-wasip1 --release
 # Use the AoT compiler for better performance
-wasmedge compile target/wasm32-wasi/release/nonblock_http_client.wasm nonblock_http_client.wasm
+wasmedge compile target/wasm32-wasip1/release/nonblock_http_client.wasm nonblock_http_client.wasm
 
 # Run the example
 wasmedge nonblock_http_client.wasm

--- a/docs/develop/rust/socket_networking/server.md
+++ b/docs/develop/rust/socket_networking/server.md
@@ -23,9 +23,9 @@ git clone https://github.com/second-state/wasmedge_wasi_socket
 cd wasmedge_wasi_socket/http_server
 
 # Build the Rust code
-cargo build --target wasm32-wasi --release
+cargo build --target wasm32-wasip1 --release
 # Use the AoT compiler for better performance
-wasmedge compile target/wasm32-wasi/release/http_server.wasm http_server.wasm
+wasmedge compile target/wasm32-wasip1/release/http_server.wasm http_server.wasm
 
 # Run the example
 $wasmedge http_server.wasm
@@ -117,9 +117,9 @@ git clone https://github.com/second-state/wasmedge_wasi_socket
 cd wasmedge_wasi_socket
 
 # Build the Rust code
-cargo build --target wasm32-wasi --release
+cargo build --target wasm32-wasip1 --release
 # Use the AoT compiler for better performance
-wasmedge compile target/wasm32-wasi/release/poll_tcp_listener.wasm poll_tcp_listener.wasm
+wasmedge compile target/wasm32-wasip1/release/poll_tcp_listener.wasm poll_tcp_listener.wasm
 
 # Run the example
 wasmedge poll_tcp_listener.wasm

--- a/docs/develop/rust/ssr.md
+++ b/docs/develop/rust/ssr.md
@@ -36,7 +36,7 @@ wasm-bindgen = { git = "https://github.com/KernelErr/wasm-bindgen.git", branch =
 
 <!-- prettier-ignore -->
 :::note
-Why do we need a forked `wasm-bindgen`? That is because `wasm-bindgen` is the required glue between Rust and HTML in the browser. On the server, however, we need to build the Rust code to the `wasm32-wasi` target, which is incompatible with `wasm-bindgen`. Our forked `wasm-bindgen` has conditional configs that remove browser-specific code in the generated `.wasm` file for the `wasm32-wasi` target.
+Why do we need a forked `wasm-bindgen`? That is because `wasm-bindgen` is the required glue between Rust and HTML in the browser. On the server, however, we need to build the Rust code to the `wasm32-wasip1` target, which is incompatible with `wasm-bindgen`. Our forked `wasm-bindgen` has conditional configs that remove browser-specific code in the generated `.wasm` file for the `wasm32-wasip1` target.
 :::
 
 Then replace the crate's `Cargo.toml` with the following content.
@@ -304,8 +304,8 @@ Next, build and run the server.
 
 ```bash
 cd ../server-wasmedge
-cargo build --target wasm32-wasi
-OUTPUT_CSS="$(pwd)/../client/build/app.css" wasmedge --dir /static:../client/build ../../../target/wasm32-wasi/debug/isomorphic-server-wasmedge.wasm
+cargo build --target wasm32-wasip1
+OUTPUT_CSS="$(pwd)/../client/build/app.css" wasmedge --dir /static:../client/build ../../../target/wasm32-wasip1/debug/isomorphic-server-wasmedge.wasm
 ```
 
 Navigate to `http://127.0.0.1:3000`, and you will see the web application in action.
@@ -330,9 +330,9 @@ Add the following to the `.cargo/config.toml` file.
 
 ```toml
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"
 
-[target.wasm32-wasi]
+[target.wasm32-wasip1]
 runner = "wasmedge --dir /static:../client/build"
 ```
 

--- a/docs/develop/rust/wasinn/llm_inference.md
+++ b/docs/develop/rust/wasinn/llm_inference.md
@@ -59,10 +59,10 @@ cd chat
 Second, use `cargo` to build the example project.
 
 ```bash
-cargo build --target wasm32-wasi --release
+cargo build --target wasm32-wasip1 --release
 ```
 
-The output WASM file is `target/wasm32-wasi/release/llama-chat.wasm`. Next, use WasmEdge to load the llama-3.1-8b model and then ask the model questions.
+The output WASM file is `target/wasm32-wasip1/release/llama-chat.wasm`. Next, use WasmEdge to load the llama-3.1-8b model and then ask the model questions.
 
 ```bash
 wasmedge --dir .:. --nn-preload default:GGML:AUTO:Meta-Llama-3.1-8B-Instruct-Q5_K_M.gguf llama-chat.wasm -p llama-3-chat

--- a/docs/develop/rust/wasinn/mediapipe.md
+++ b/docs/develop/rust/wasinn/mediapipe.md
@@ -22,8 +22,8 @@ cd demo-object-detection/
 Build an inference application using the Mediapipe object detection model.
 
 ```bash
-cargo build --target wasm32-wasi --release
-wasmedge compile target/wasm32-wasi/release/demo-object-detection.wasm demo-object-detection.wasm
+cargo build --target wasm32-wasip1 --release
+wasmedge compile target/wasm32-wasip1/release/demo-object-detection.wasm demo-object-detection.wasm
 ```
 
 Run the inference application against an image. The input `example.jpg` image is shown below.

--- a/docs/develop/rust/wasinn/openvino.md
+++ b/docs/develop/rust/wasinn/openvino.md
@@ -55,10 +55,10 @@ cd WasmEdge-WASINN-examples/openvino-mobilenet-image/rust/
 Second, use `cargo` to build the template project.
 
 ```bash
-cargo build --target wasm32-wasi --release
+cargo build --target wasm32-wasip1 --release
 ```
 
-The output WASM file is `target/wasm32-wasi/release/wasmedge-wasinn-example-mobilenet-image.wasm`. Download the OpenVINO model files. Next, use WasmEdge to load the OpenVINO model and then use it to classify objects in your image.
+The output WASM file is `target/wasm32-wasip1/release/wasmedge-wasinn-example-mobilenet-image.wasm`. Download the OpenVINO model files. Next, use WasmEdge to load the OpenVINO model and then use it to classify objects in your image.
 
 ```bash
 ./download_mobilenet.sh

--- a/docs/develop/rust/wasinn/pytorch.md
+++ b/docs/develop/rust/wasinn/pytorch.md
@@ -52,10 +52,10 @@ cd WasmEdge-WASINN-examples/pytorch-mobilenet-image/rust
 Second, use `cargo` to build the example project.
 
 ```bash
-cargo build --target wasm32-wasi --release
+cargo build --target wasm32-wasip1 --release
 ```
 
-The output WASM file is `target/wasm32-wasi/release/wasmedge-wasinn-example-mobilenet-image.wasm`. Next, use WasmEdge to load the PyTorch model and then use it to classify objects in your image.
+The output WASM file is `target/wasm32-wasip1/release/wasmedge-wasinn-example-mobilenet-image.wasm`. Next, use WasmEdge to load the PyTorch model and then use it to classify objects in your image.
 
 ```bash
 wasmedge --dir .:. wasmedge-wasinn-example-mobilenet-image.wasm mobilenet.pt input.jpg

--- a/docs/develop/rust/wasinn/tensorflow_lite.md
+++ b/docs/develop/rust/wasinn/tensorflow_lite.md
@@ -52,10 +52,10 @@ cd WasmEdge-WASINN-examples/tflite-birds_v1-image/rust/
 Second, use `cargo` to build the example project.
 
 ```bash
-cargo build --target wasm32-wasi --release
+cargo build --target wasm32-wasip1 --release
 ```
 
-The output WASM file is `target/wasm32-wasi/release/wasmedge-wasinn-example-tflite-bird-image.wasm`. Next, let's use WasmEdge to load the Tensorflow Lite model and then use it to classify objects in your image.
+The output WASM file is `target/wasm32-wasip1/release/wasmedge-wasinn-example-tflite-bird-image.wasm`. Next, let's use WasmEdge to load the Tensorflow Lite model and then use it to classify objects in your image.
 
 ```bash
 wasmedge --dir .:. wasmedge-wasinn-example-tflite-bird-image.wasm lite-model_aiy_vision_classifier_birds_V1_3.tflite bird.jpg

--- a/docs/develop/rust/wasinn/tf_plugin.md
+++ b/docs/develop/rust/wasinn/tf_plugin.md
@@ -125,10 +125,10 @@ let res_vec: Vec<f32> = session.get_output("MobilenetV2/Predictions/Softmax");
 After completing your code, you can follow the command to compile into WASM.
 
 ```bash
-cargo build --target=wasm32-wasi
+cargo build --target=wasm32-wasip1
 ```
 
-The output WASM file will be at `target/wasm32-wasi/debug/` or `target/wasm32-wasi/release`.
+The output WASM file will be at `target/wasm32-wasip1/debug/` or `target/wasm32-wasip1/release`.
 
 Please refer to [WasmEdge CLI](../../../start/build-and-run/cli.md) for WASM execution.
 

--- a/docs/embed/go/ai.md
+++ b/docs/embed/go/ai.md
@@ -38,8 +38,8 @@ You can build the standard `Cargo` command into a WebAssembly function.
 ```bash
 git clone https://github.com/second-state/WasmEdge-go-examples.git
 cd go_TfliteFood/rust_tflite_food
-cargo build --target wasm32-wasi --release
-cp target/wasm32-wasi/release/rust_tflite_food_lib.wasm ../
+cargo build --target wasm32-wasip1 --release
+cp target/wasm32-wasip1/release/rust_tflite_food_lib.wasm ../
 cd ../
 ```
 

--- a/docs/embed/go/app.md
+++ b/docs/embed/go/app.md
@@ -68,8 +68,8 @@ Next, let's compile the application into WebAssembly.
 ```bash
 git clone https://github.com/second-state/WasmEdge-go-examples.git
 cd rust_readfile
-cargo build --target wasm32-wasi
-# The output file will be target/wasm32-wasi/debug/rust_readfile.wasm
+cargo build --target wasm32-wasip1
+# The output file will be target/wasm32-wasip1/debug/rust_readfile.wasm
 ```
 
 ## The Go Host app
@@ -118,7 +118,7 @@ go build
 Run the Golang application.
 
 ```bash
-$ ./read_file rust_readfile/target/wasm32-wasi/debug/rust_readfile.wasm file.txt
+$ ./read_file rust_readfile/target/wasm32-wasip1/debug/rust_readfile.wasm file.txt
 Rust: Opening input file "file.txt"...
 Rust: Read input file "file.txt" succeeded.
 Rust: Please input the line number to print the line of file.

--- a/docs/embed/go/bindgen.md
+++ b/docs/embed/go/bindgen.md
@@ -93,8 +93,8 @@ First, we will compile the Rust source code into WebAssembly bytecode functions.
 ```bash
 git clone https://github.com/second-state/WasmEdge-go-examples.git
 cd rust_bindgen_funcs
-$cargo build --release --target wasm32-wasi
-# The output WASM will be target/wasm32-wasi/release/rust_bindgen_funcs_lib.wasm
+$cargo build --release --target wasm32-wasip1
+# The output WASM will be target/wasm32-wasip1/release/rust_bindgen_funcs_lib.wasm
 ```
 
 ## The Go host app
@@ -203,7 +203,7 @@ go build
 Run the Go application and it will run the WebAssembly functions embedded in the WasmEdge runtime.
 
 ```bash
-$ ./bindgen_funcs rust_bindgen_funcs/target/wasm32-wasi/release/rust_bindgen_funcs_lib.wasm
+$ ./bindgen_funcs rust_bindgen_funcs/target/wasm32-wasip1/release/rust_bindgen_funcs_lib.wasm
 Run bindgen -- create_line: {"points":[{"x":1.5,"y":3.8},{"x":2.5,"y":5.8}],"valid":true,"length":2.2360682,"desc":"A thin red line"}
 Run bindgen -- say: hello bindgen funcs test
 Run bindgen -- obfusticate: N dhvpx oebja sbk whzcf bire gur ynml qbt

--- a/docs/embed/go/function.md
+++ b/docs/embed/go/function.md
@@ -93,8 +93,8 @@ First, we will compile the Rust source code into WebAssembly bytecode functions.
 ```bash
 git clone https://github.com/second-state/WasmEdge-go-examples.git
 cd rust_bindgen_funcs
-cargo build --release --target wasm32-wasi
-# The output WASM will be target/wasm32-wasi/release/rust_bindgen_funcs_lib.wasm
+cargo build --release --target wasm32-wasip1
+# The output WASM will be target/wasm32-wasip1/release/rust_bindgen_funcs_lib.wasm
 ```
 
 ## The Go host app
@@ -203,7 +203,7 @@ go build
 Run the Go application, and it will run the WebAssembly functions embedded in the WasmEdge runtime.
 
 ```bash
-$ ./bindgen_funcs rust_bindgen_funcs/target/wasm32-wasi/release/rust_bindgen_funcs_lib.wasm
+$ ./bindgen_funcs rust_bindgen_funcs/target/wasm32-wasip1/release/rust_bindgen_funcs_lib.wasm
 Run bindgen -- create_line: {"points":[{"x":1.5,"y":3.8},{"x":2.5,"y":5.8}],"valid":true,"length":2.2360682,"desc":"A thin red line"}
 Run bindgen -- say: hello bindgen funcs test
 Run bindgen -- obfusticate: N dhvpx oebja sbk whzcf bire gur ynml qbt

--- a/docs/embed/go/passing_data.md
+++ b/docs/embed/go/passing_data.md
@@ -63,8 +63,8 @@ Use standard Rust compiler tools to compile the Rust source code into a WebAssem
 
 ```bash
 cd rust_memory_greet
-cargo build --target wasm32-wasi
-# The output WASM will be `target/wasm32-wasi/debug/rust_memory_greet_lib.wasm`.
+cargo build --target wasm32-wasip1
+# The output WASM will be `target/wasm32-wasip1/debug/rust_memory_greet_lib.wasm`.
 ```
 
 The [Go SDK application](https://github.com/second-state/WasmEdge-go-examples/blob/master/go_MemoryGreet/greet_memory.go) must call `allocate` from the WasmEdge VM to get a pointer to the string parameter. It will then call the `greet` function in Rust with the pointer. After the function returns, the Go application will call `deallocate` to free the memory space.
@@ -367,8 +367,8 @@ Use standard Rust compiler tools to compile the Rust source code into a WebAssem
 
 ```bash
 cd rust_access_memory
-cargo build --target wasm32-wasi
-# The output WASM will be target/wasm32-wasi/debug/rust_access_memory_lib.wasm.
+cargo build --target wasm32-wasip1
+# The output WASM will be target/wasm32-wasip1/debug/rust_access_memory_lib.wasm.
 ```
 
 The [Go SDK application](https://github.com/second-state/WasmEdge-go-examples/blob/master/go_AccessMemory/run.go) must call `allocate` from the WasmEdge VM to get a pointer to the array. It will then call the `fib_array()` function in Rust and pass in the pointer. After the functions return, the Go application will use the WasmEdge `store` API to construct an array from the pointer in the call parameter (`fib_array()`) or in the return value (`fib_array_return_memory()`). The Go app will eventually call `deallocate` to free the memory space.

--- a/docs/embed/go/reference/0.9.x.md
+++ b/docs/embed/go/reference/0.9.x.md
@@ -193,10 +193,10 @@ pub fn keccak_digest(s: Vec<u8>) -> Vec<u8> {
 First, compile the Rust source code into WebAssembly bytecode functions.
 
 ```bash
-rustup target add wasm32-wasi
+rustup target add wasm32-wasip1
 cd rust_bindgen_funcs
-cargo build --target wasm32-wasi --release
-# The output WASM will be target/wasm32-wasi/release/rust_bindgen_funcs_lib.wasm
+cargo build --target wasm32-wasip1 --release
+# The output WASM will be target/wasm32-wasip1/release/rust_bindgen_funcs_lib.wasm
 ```
 
 The [Golang source code](https://github.com/second-state/WasmEdge-go-examples/blob/master/wasmedge-bindgen/go_BindgenFuncs/bindgen_funcs.go) to run the WebAssembly function in WasmEdge is as follows. The `bg.Execute()` function calls the WebAssembly function and passes the parameters with the `wasmedge-bindgen` supporting.
@@ -305,7 +305,7 @@ go build
 Run the Golang application and it will run the WebAssembly functions embedded in the WasmEdge runtime.
 
 ```bash
-$ ./bindgen_funcs rust_bindgen_funcs/target/wasm32-wasi/release/rust_bindgen_funcs_lib.wasm
+$ ./bindgen_funcs rust_bindgen_funcs/target/wasm32-wasip1/release/rust_bindgen_funcs_lib.wasm
 Run bindgen -- create_line: {"points":[{"x":2.5,"y":7.8},{"x":2.5,"y":5.8}],"valid":true,"length":2.0,"desc":"A thin red line"}
 Run bindgen -- say: hello bindgen funcs test
 Run bindgen -- obfusticate: N dhvpx oebja sbk whzcf bire gur ynml qbt
@@ -385,10 +385,10 @@ Or you can compile the application into WebAssembly directly by `cargo`:
 
 ```bash
 cd rust_readfile
-# Need to add the `wasm32-wasi` target.
-rustup target add wasm32-wasi
-cargo build --release --target=wasm32-wasi
-# The output wasm will be at `target/wasm32-wasi/release/rust_readfile.wasm`.
+# Need to add the `wasm32-wasip1` target.
+rustup target add wasm32-wasip1
+cargo build --release --target=wasm32-wasip1
+# The output wasm will be at `target/wasm32-wasip1/release/rust_readfile.wasm`.
 ```
 
 The Golang source code to run the WebAssembly function in WasmEdge is as follows.

--- a/docs/embed/quick-start/wasm-app-in-rust.md
+++ b/docs/embed/quick-start/wasm-app-in-rust.md
@@ -13,7 +13,7 @@ The [wasmedge-bindgen](https://github.com/second-state/wasmedge-bindgen) project
 
 ## Prerequisites
 
-We need to install [Rust and add `wasm32-wasi` target for Rust](../../develop/rust/setup.md)
+We need to install [Rust and add `wasm32-wasip1` target for Rust](../../develop/rust/setup.md)
 
 We also need to install `wasmedge-bindgen`.
 
@@ -115,9 +115,9 @@ Next, build the WebAssembly bytecode file using standard `Cargo` commands.
 
 ```bash
 cd rust_bindgen_funcs
-cargo build --target wasm32-wasi --release
-# The output WASM will be target/wasm32-wasi/release/rust_bindgen_funcs_lib.wasm.
-cp target/wasm32-wasi/release/rust_bindgen_funcs_lib.wasm ../
+cargo build --target wasm32-wasip1 --release
+# The output WASM will be target/wasm32-wasip1/release/rust_bindgen_funcs_lib.wasm.
+cp target/wasm32-wasip1/release/rust_bindgen_funcs_lib.wasm ../
 cd ../
 ```
 

--- a/docs/embed/use-case/libsql.md
+++ b/docs/embed/use-case/libsql.md
@@ -21,12 +21,12 @@ make
 
 ## The encrypt and decrypt example
 
-Build the encrypt and decrypt example into wasm. Since WasmEdge supports WASI functions here, we will use the `wasm32-wasi` target.
+Build the encrypt and decrypt example into wasm. Since WasmEdge supports WASI functions here, we will use the `wasm32-wasip1` target.
 
 ```bash
 git clone https://github.com/libsql/libsql_bindgen
 cd libsql_bindgen/examples/encrypt_decrypt
-cargo build --target wasm32-wasi --release
+cargo build --target wasm32-wasip1 --release
 ```
 
 Then, we can build a SQL file for creating the `encrypt` function in a libSQL database.
@@ -35,7 +35,7 @@ Then, we can build a SQL file for creating the `encrypt` function in a libSQL da
 export FUNC_NAME='encrypt'
 echo "DROP FUNCTION IF EXISTS ${FUNC_NAME};" >> create_${FUNC_NAME}_udf.sql
 echo -n "CREATE FUNCTION ${FUNC_NAME} LANGUAGE wasm AS X'" >> create_${FUNC_NAME}_udf.sql
-xxd -p  ../../target/wasm32-wasi/release/libsql_encrypt_decrypt.wasm | tr -d "\n" >> create_${FUNC_NAME}_udf.sql
+xxd -p  ../../target/wasm32-wasip1/release/libsql_encrypt_decrypt.wasm | tr -d "\n" >> create_${FUNC_NAME}_udf.sql
 echo "';" >> create_${FUNC_NAME}_udf.sql
 ```
 
@@ -45,7 +45,7 @@ Create another SQL file for the `decrypt` function.
 export FUNC_NAME='decrypt'
 echo "DROP FUNCTION IF EXISTS ${FUNC_NAME};" >> create_${FUNC_NAME}_udf.sql
 echo -n "CREATE FUNCTION ${FUNC_NAME} LANGUAGE wasm AS X'" >> create_${FUNC_NAME}_udf.sql
-xxd -p  ../../target/wasm32-wasi/release/libsql_encrypt_decrypt.wasm | tr -d "\n" >> create_${FUNC_NAME}_udf.sql
+xxd -p  ../../target/wasm32-wasip1/release/libsql_encrypt_decrypt.wasm | tr -d "\n" >> create_${FUNC_NAME}_udf.sql
 echo "';" >> create_${FUNC_NAME}_udf.sql
 ```
 

--- a/docs/embed/use-case/wasm-nginx.md
+++ b/docs/embed/use-case/wasm-nginx.md
@@ -86,7 +86,7 @@ We also provide a Rust version (including Cargo.toml and others) [here](https://
 ### Rust Step 2: Build the corresponding WASM file
 
 ```shell
-cargo build --target=wasm32-wasi
+cargo build --target=wasm32-wasip1
 ```
 
 ### Rust Step 3: Load and execute the WASM file
@@ -107,7 +107,7 @@ http {
     init_by_lua_block {
         local wasm = require("resty.proxy-wasm")
         package.loaded.plugin = assert(wasm.load("fault_injection",
-            "/path/to/fault-injection/target/wasm32-wasi/debug/fault_injection.wasm"))
+            "/path/to/fault-injection/target/wasm32-wasip1/debug/fault_injection.wasm"))
     }
     server {
         listen 1980;

--- a/docs/embed/use-case/yomo.md
+++ b/docs/embed/use-case/yomo.md
@@ -125,17 +125,17 @@ pub fn infer(image_data: Vec<u8>) -> Result<Vec<u8>, String> {
 }
 ```
 
-You should add `wasm32-wasi` target to rust to compile this function into WebAssembly bytecode.
+You should add `wasm32-wasip1` target to rust to compile this function into WebAssembly bytecode.
 
 ```bash
-rustup target add wasm32-wasi
+rustup target add wasm32-wasip1
 
 cd flow/rust_mobilenet_food
-cargo build --target wasm32-wasi --release
-# The output WASM will be target/wasm32-wasi/release/rust_mobilenet_food_lib.wasm
+cargo build --target wasm32-wasip1 --release
+# The output WASM will be target/wasm32-wasip1/release/rust_mobilenet_food_lib.wasm
 
 # Copy the wasm bytecode file to the flow/ directory
-cp target/wasm32-wasi/release/rust_mobilenet_food_lib.wasm ../
+cp target/wasm32-wasip1/release/rust_mobilenet_food_lib.wasm ../
 ```
 
 To release the best performance of WasmEdge, you should enable the AOT mode by compiling the `.wasm` file to the `.so`.

--- a/docs/start/build-and-run/cli.md
+++ b/docs/start/build-and-run/cli.md
@@ -108,13 +108,13 @@ The Hello World example is a standalone Rust application that can be executed by
 You will need to have the [Rust compiler installed](https://github.com/second-state/rust-examples/blob/main/README.md#prerequisites), and then use the following command to build the WASM bytecode file from the Rust source code.
 
 ```bash
-cargo build --target wasm32-wasi --release
+cargo build --target wasm32-wasip1 --release
 ```
 
 You can then use the `wasmedge` command to run the program.
 
 ```bash
-$ wasmedge target/wasm32-wasi/release/hello.wasm
+$ wasmedge target/wasm32-wasip1/release/hello.wasm
 Hello WasmEdge!
 ```
 
@@ -197,7 +197,7 @@ The [add](https://github.com/second-state/wasm-learning/tree/master/cli/add) pro
 You will need to have the [Rust compiler](https://github.com/second-state/rust-examples/blob/main/README.md#prerequisites) installed, and then use the following command to build the WASM bytecode file from the Rust source code.
 
 ```bash
-cargo build --target wasm32-wasi --release
+cargo build --target wasm32-wasip1 --release
 ```
 
 You can execute `wasmedge` in reactor mode to invoke the `add()` function with two `i32` integer input parameters.

--- a/docs/start/build-and-run/docker_wasm.md
+++ b/docs/start/build-and-run/docker_wasm.md
@@ -43,7 +43,7 @@ RUN <<EOT bash
     apt-get install -y \
         git \
         clang
-    rustup target add wasm32-wasi
+    rustup target add wasm32-wasip1
 EOT
 ```
 
@@ -54,7 +54,7 @@ FROM buildbase AS build
 COPY Cargo.toml .
 COPY src ./src
 # Build the WASM binary
-RUN cargo build --target wasm32-wasi --release
+RUN cargo build --target wasm32-wasip1 --release
 ```
 
 The third part is the essential. It copies the WASM file into an empty `scratch` container and then set the WASM file as the `ENTRYPOINT` of the container. It is the container image `rust-example-hello` built by the command in this section.
@@ -62,7 +62,7 @@ The third part is the essential. It copies the WASM file into an empty `scratch`
 ```dockerfile
 FROM scratch
 ENTRYPOINT [ "hello.wasm" ]
-COPY --link --from=build /src/target/wasm32-wasi/release/hello.wasm /hello.wasm
+COPY --link --from=build /src/target/wasm32-wasip1/release/hello.wasm /hello.wasm
 ```
 
 The WASM container image is only 0.5MB. It is much smaller than a natively compiled Rust program in a minimal Linux container.

--- a/docs/start/usage/serverless/aws.md
+++ b/docs/start/usage/serverless/aws.md
@@ -10,10 +10,10 @@ In this article, we will show you two serverless functions in Rust and WasmEdge 
 
 ## Prerequisites
 
-Since our demo WebAssembly functions are written in Rust, you will need a [Rust compiler](https://www.rust-lang.org/tools/install). Make sure that you install the `wasm32-wasi` compiler target as follows, in order to generate WebAssembly bytecode.
+Since our demo WebAssembly functions are written in Rust, you will need a [Rust compiler](https://www.rust-lang.org/tools/install). Make sure that you install the `wasm32-wasip1` compiler target as follows, in order to generate WebAssembly bytecode.
 
 ```bash
-rustup target add wasm32-wasi
+rustup target add wasm32-wasip1
 ```
 
 The demo application front end is written in [Next.js](https://nextjs.org/), and deployed on AWS Lambda. We will assume that you already have the basic knowledge of how to work with Next.js and Lambda.
@@ -58,13 +58,13 @@ You can use Rust’s `cargo` tool to build the Rust program into WebAssembly byt
 
 ```bash
 cd api/functions/image-grayscale/
-cargo build --release --target wasm32-wasi
+cargo build --release --target wasm32-wasip1
 ```
 
 Copy the build artifacts to the `api` folder.
 
 ```bash
-cp target/wasm32-wasi/release/grayscale.wasm ../../
+cp target/wasm32-wasip1/release/grayscale.wasm ../../
 ```
 
 > When we build the docker image, `api/pre.sh` is executed. `pre.sh` installs the WasmEdge runtime, and then compiles each WebAssembly bytecode program into a native `so` library for faster execution.
@@ -225,13 +225,13 @@ You can use the `cargo` tool to build the Rust program into WebAssembly bytecode
 
 ```bash
 cd api/functions/image-classification/
-cargo build --release --target wasm32-wasi
+cargo build --release --target wasm32-wasip1
 ```
 
 Copy the build artifacts to the `api` folder.
 
 ```bash
-cp target/wasm32-wasi/release/classify.wasm ../../
+cp target/wasm32-wasip1/release/classify.wasm ../../
 ```
 
 Again, the `api/pre.sh` script installs WasmEdge runtime and its Tensorflow dependencies in this application. It also compiles the `classify.wasm` bytecode program to the `classify.so` native shared library at the time of deployment.

--- a/docs/start/usage/serverless/netlify.md
+++ b/docs/start/usage/serverless/netlify.md
@@ -10,10 +10,10 @@ In this article we will show you two serverless functions in Rust and WasmEdge d
 
 ## Prerequisite
 
-Since our demo WebAssembly functions are written in Rust, you will need a [Rust compiler](https://www.rust-lang.org/tools/install). Make sure that you install the `wasm32-wasi` compiler target as follows, in order to generate WebAssembly bytecode.
+Since our demo WebAssembly functions are written in Rust, you will need a [Rust compiler](https://www.rust-lang.org/tools/install). Make sure that you install the `wasm32-wasip1` compiler target as follows, in order to generate WebAssembly bytecode.
 
 ```bash
-rustup target add wasm32-wasi
+rustup target add wasm32-wasip1
 ```
 
 The demo application front end is written in [Next.js](https://nextjs.org/), and deployed on Netlify. We will assume that you already have the basic knowledge of how to work with Next.js and Netlify.
@@ -56,13 +56,13 @@ You can use Rust’s `cargo` tool to build the Rust program into WebAssembly byt
 
 ```bash
 cd api/functions/image-grayscale/
-cargo build --release --target wasm32-wasi
+cargo build --release --target wasm32-wasip1
 ```
 
 Copy the build artifacts to the `api` folder.
 
 ```bash
-cp target/wasm32-wasi/release/grayscale.wasm ../../
+cp target/wasm32-wasip1/release/grayscale.wasm ../../
 ```
 
 > The Netlify function runs [`api/pre.sh`](https://github.com/second-state/netlify-wasm-runtime/blob/main/api/pre.sh) upon setting up the serverless environment. It installs the WasmEdge runtime, and then compiles each WebAssembly bytecode program into a native `so` library for faster execution.
@@ -144,13 +144,13 @@ You can use the `cargo` tool to build the Rust program into WebAssembly bytecode
 
 ```bash
 cd api/functions/image-classification/
-cargo build --release --target wasm32-wasi
+cargo build --release --target wasm32-wasip1
 ```
 
 Copy the build artifacts to the `api` folder.
 
 ```bash
-cp target/wasm32-wasi/release/classify.wasm ../../
+cp target/wasm32-wasip1/release/classify.wasm ../../
 ```
 
 Again, the [`api/pre.sh`](https://github.com/second-state/netlify-wasm-runtime/blob/tensorflow/api/pre.sh) script installs WasmEdge runtime and its Tensorflow dependencies in this application. It also compiles the `classify.wasm` bytecode program to the `classify.so` native shared library at the time of deployment.

--- a/docs/start/usage/serverless/vercel.md
+++ b/docs/start/usage/serverless/vercel.md
@@ -10,10 +10,10 @@ In this article, we will show you two serverless functions in Rust and WasmEdge 
 
 ## Prerequisite
 
-Since our demo WebAssembly functions are written in Rust, you will need a [Rust compiler](https://www.rust-lang.org/tools/install). Make sure that you install the `wasm32-wasi` compiler target as follows, in order to generate WebAssembly bytecode.
+Since our demo WebAssembly functions are written in Rust, you will need a [Rust compiler](https://www.rust-lang.org/tools/install). Make sure that you install the `wasm32-wasip1` compiler target as follows, in order to generate WebAssembly bytecode.
 
 ```bash
-rustup target add wasm32-wasi
+rustup target add wasm32-wasip1
 ```
 
 The demo application front end is written in [Next.js](https://nextjs.org/), and deployed on Vercel. We will assume that you already have the basic knowledge of how to work with Vercel.
@@ -56,13 +56,13 @@ You can use Rust’s `cargo` tool to build the Rust program into WebAssembly byt
 
 ```bash
 cd api/functions/image-grayscale/
-cargo build --release --target wasm32-wasi
+cargo build --release --target wasm32-wasip1
 ```
 
 Copy the build artifacts to the `api` folder.
 
 ```bash
-cp target/wasm32-wasi/release/grayscale.wasm ../../
+cp target/wasm32-wasip1/release/grayscale.wasm ../../
 ```
 
 > Vercel runs [`api/pre.sh`](https://github.com/second-state/vercel-wasm-runtime/blob/main/api/pre.sh) upon setting up the serverless environment. It installs the WasmEdge runtime, and then compiles each WebAssembly bytecode program into a native `so` library for faster execution.
@@ -146,13 +146,13 @@ You can use the `cargo` tool to build the Rust program into WebAssembly bytecode
 
 ```bash
 cd api/functions/image-classification/
-cargo build --release --target wasm32-wasi
+cargo build --release --target wasm32-wasip1
 ```
 
 Copy the build artifacts to the `api` folder.
 
 ```bash
-cp target/wasm32-wasi/release/classify.wasm ../../
+cp target/wasm32-wasip1/release/classify.wasm ../../
 ```
 
 Again, the [`api/pre.sh`](https://github.com/second-state/vercel-wasm-runtime/blob/tensorflow/api/pre.sh) script installs WasmEdge runtime and its Tensorflow dependencies in this application. It also compiles the `classify.wasm` bytecode program to the `classify.so` native shared library at the time of deployment.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/contribute/source/os/android/cli.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/contribute/source/os/android/cli.md
@@ -74,17 +74,17 @@ git clone https://github.com/second-state/wasm-learning.git
 cd wasm-learning/rust/birds_v1
 ```
 
-Use the `cargo` command to build a WASM bytecode file from the Rust source code. The WASM file is located at `target/wasm32-wasi/release/birds_v1.wasm`.
+Use the `cargo` command to build a WASM bytecode file from the Rust source code. The WASM file is located at `target/wasm32-wasip1/release/birds_v1.wasm`.
 
 ```bash
-rustup target add wasm32-wasi
-cargo build --release --target=wasm32-wasi
+rustup target add wasm32-wasip1
+cargo build --release --target=wasm32-wasip1
 ```
 
 Push the WASM bytecode file, tensorflow lite model file, and the test bird picture file onto the Android device using `adb`.
 
 ```bash
-adb push target/wasm32-wasi/release/birds_v1.wasm /data/local/tmp/WasmEdge-tensorflow-tools
+adb push target/wasm32-wasip1/release/birds_v1.wasm /data/local/tmp/WasmEdge-tensorflow-tools
 adb push lite-model_aiy_vision_classifier_birds_V1_3.tflite /data/local/tmp/WasmEdge-tensorflow-tools
 adb push bird.jpg /data/local/tmp/WasmEdge-tensorflow-tools
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/current/develop/c/simd.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/develop/c/simd.md
@@ -6,9 +6,9 @@ sidebar_position: 4
 
 [128-bit packed Single Instruction Multiple Data (SIMD)](https://webassembly.github.io/simd/core/syntax/instructions.html#simd-instructions) instructions provide simultaneous computations over packed data in just one instruction. It's commonly used to improve performance for multimedia applications. With the SIMD proposal, the modules can benefit from using these commonly used instructions in modern hardware to gain more speedup.
 
-If you are interested in enabling the SIMD proposal will improve how much performance of the applications, please refer to our [wasm32-wasip1 benchmark](https://github.com/second-state/wasm32-wasip1-benchmark) for more information. The Mandelbrot Set application can have a **2.65x** speedup in our benchmark.
+If you are interested in enabling the SIMD proposal will improve how much performance of the applications, please refer to our [wasm32-wasip1 benchmark](https://github.com/second-state/wasm32-wasi-benchmark) for more information. The Mandelbrot Set application can have a **2.65x** speedup in our benchmark.
 
-We modified the Mandelbrot Set example from our [wasm32-wasip1 benchmark project](https://github.com/second-state/wasm32-wasip1-benchmark/blob/master/src/mandelbrot.c). We will use this as an example in this article.
+We modified the Mandelbrot Set example from our [wasm32-wasip1 benchmark project](https://github.com/second-state/wasm32-wasi-benchmark/blob/master/src/mandelbrot.c). We will use this as an example in this article.
 
 ## Prerequisites
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/develop/c/simd.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/develop/c/simd.md
@@ -6,9 +6,9 @@ sidebar_position: 4
 
 [128-bit packed Single Instruction Multiple Data (SIMD)](https://webassembly.github.io/simd/core/syntax/instructions.html#simd-instructions) instructions provide simultaneous computations over packed data in just one instruction. It's commonly used to improve performance for multimedia applications. With the SIMD proposal, the modules can benefit from using these commonly used instructions in modern hardware to gain more speedup.
 
-If you are interested in enabling the SIMD proposal will improve how much performance of the applications, please refer to our [wasm32-wasi benchmark](https://github.com/second-state/wasm32-wasi-benchmark) for more information. The Mandelbrot Set application can have a **2.65x** speedup in our benchmark.
+If you are interested in enabling the SIMD proposal will improve how much performance of the applications, please refer to our [wasm32-wasip1 benchmark](https://github.com/second-state/wasm32-wasip1-benchmark) for more information. The Mandelbrot Set application can have a **2.65x** speedup in our benchmark.
 
-We modified the Mandelbrot Set example from our [wasm32-wasi benchmark project](https://github.com/second-state/wasm32-wasi-benchmark/blob/master/src/mandelbrot.c). We will use this as an example in this article.
+We modified the Mandelbrot Set example from our [wasm32-wasip1 benchmark project](https://github.com/second-state/wasm32-wasip1-benchmark/blob/master/src/mandelbrot.c). We will use this as an example in this article.
 
 ## Prerequisites
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/develop/javascript/hello_world.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/develop/javascript/hello_world.md
@@ -76,7 +76,7 @@ git clone https://github.com/second-state/wasmedge-quickjs
 cd wasmedge-quickjs
 
 # Build the QuickJS JavaScript interpreter
-cargo build --target wasm32-wasi --release
+cargo build --target wasm32-wasip1 --release
 ```
 
 The WebAssembly-based JavaScript interpreter program is located in the build `target` directory.
@@ -84,7 +84,7 @@ The WebAssembly-based JavaScript interpreter program is located in the build `ta
 WasmEdge provides a `wasmedgec` utility to compile and add a native machine code section to the `wasm` file. You can use `wasmedge` to run the natively instrumented `wasm` file to get a much faster performance.
 
 ```bash
-wasmedge compile target/wasm32-wasi/release/wasmedge_quickjs.wasm wasmedge_quickjs.wasm
+wasmedge compile target/wasm32-wasip1/release/wasmedge_quickjs.wasm wasmedge_quickjs.wasm
 wasmedge --dir .:. wasmedge_quickjs.wasm example_js/hello.js
 ```
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/develop/javascript/rust.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/develop/javascript/rust.md
@@ -22,8 +22,8 @@ The examples are in the `examples/embed_js` folder in the `wasmedge-quickjs` rep
 
 ```bash
 cd examples/embed_js
-cargo build --target wasm32-wasi --release
-wasmedge --dir .:. target/wasm32-wasi/release/embed_js.wasm
+cargo build --target wasm32-wasip1 --release
+wasmedge --dir .:. target/wasm32-wasip1/release/embed_js.wasm
 ```
 
 ## Code explanation: embed JavaScript into a Rust program
@@ -191,8 +191,8 @@ The project is in the [examples/embed_rust_module](https://github.com/second-sta
 
 ```bash
 cd examples/embed_rust_module
-cargo build --target wasm32-wasi --release
-wasmedge --dir .:. target/wasm32-wasi/release/embed_rust_module.wasm
+cargo build --target wasm32-wasip1 --release
+wasmedge --dir .:. target/wasm32-wasip1/release/embed_rust_module.wasm
 ```
 
 ### Code explanation

--- a/i18n/zh/docusaurus-plugin-content-docs/current/develop/javascript/tensorflow.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/develop/javascript/tensorflow.md
@@ -103,7 +103,7 @@ git clone https://github.com/second-state/wasmedge-quickjs
 cd wasmedge-quickjs
 
 # Build the QuickJS JavaScript interpreter with WASI NN
-cargo build --target wasm32-wasi --release --features=wasi_nn
+cargo build --target wasm32-wasip1 --release --features=wasi_nn
 ```
 
 The WebAssembly-based JavaScript interpreter program is located in the build `target` directory.
@@ -111,5 +111,5 @@ The WebAssembly-based JavaScript interpreter program is located in the build `ta
 WasmEdge provides a `wasmedge compile` utility to compile and add a native machine code section to the wasm file. You can use wasmedge to run the natively instrumented wasm file to get much faster performance.
 
 ```bash
-wasmedge compile target/wasm32-wasi/release/wasmedge_quickjs.wasm wasmedge_quickjs_nn.wasm
+wasmedge compile target/wasm32-wasip1/release/wasmedge_quickjs.wasm wasmedge_quickjs_nn.wasm
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/current/develop/python/hello_world.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/develop/python/hello_world.md
@@ -8,10 +8,10 @@ Several different language implementations of the Python runtime exist, and some
 
 ## Compile RustPython
 
-To compile RustPython, you should install the Rust toolchain on your machine. And `wasm32-wasi` platform support should be enabled.
+To compile RustPython, you should install the Rust toolchain on your machine. And `wasm32-wasip1` platform support should be enabled.
 
 ```bash
-rustup target add wasm32-wasi
+rustup target add wasm32-wasip1
 ```
 
 Then you could use the following command to clone and compile RustPython:
@@ -19,23 +19,23 @@ Then you could use the following command to clone and compile RustPython:
 ```bash
 git clone https://github.com/RustPython/RustPython.git
 cd RustPython
-cargo build --release --target wasm32-wasi --features="freeze-stdlib"
+cargo build --release --target wasm32-wasip1 --features="freeze-stdlib"
 ```
 
-`freeze-stdlib` feature is enabled for including Python standard library inside the binary file. The output file should be at `target/wasm32-wasi/release/rustpython.wasm`.
+`freeze-stdlib` feature is enabled for including Python standard library inside the binary file. The output file should be at `target/wasm32-wasip1/release/rustpython.wasm`.
 
 ## AOT Compile
 
 WasmEdge supports compiling WebAssembly bytecode programs into native machine code for better performance. It is highly recommended to compile the RustPython to native machine code before running.
 
 ```bash
-wasmedge compile ./target/wasm32-wasi/release/rustpython.wasm ./target/wasm32-wasi/release/rustpython.wasm
+wasmedge compile ./target/wasm32-wasip1/release/rustpython.wasm ./target/wasm32-wasip1/release/rustpython.wasm
 ```
 
 ## Run
 
 ```bash
-wasmedge ./target/wasm32-wasi/release/rustpython.wasm
+wasmedge ./target/wasm32-wasip1/release/rustpython.wasm
 ```
 
 Then you could get a Python shell in WebAssembly!
@@ -45,5 +45,5 @@ Then you could get a Python shell in WebAssembly!
 You can pre-open directories to let WASI programs have permission to read and write files stored on the real machine. The following command mounted the current working directory to the WASI virtual file system.
 
 ```bash
-wasmedge --dir .:. ./target/wasm32-wasi/release/rustpython.wasm
+wasmedge --dir .:. ./target/wasm32-wasip1/release/rustpython.wasm
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/current/develop/rust/dapr.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/develop/rust/dapr.md
@@ -59,8 +59,8 @@ Build.
 
 ```bash
 cd image-api-grayscale
-cargo build --target wasm32-wasi --release
-wasmedgec ./target/wasm32-wasi/release/image-api-grayscale.wasm image-api-grayscale.wasm
+cargo build --target wasm32-wasip1 --release
+wasmedgec ./target/wasm32-wasip1/release/image-api-grayscale.wasm image-api-grayscale.wasm
 ```
 
 Deploy.
@@ -81,8 +81,8 @@ Build.
 
 ```bash
 cd image-api-classify
-cargo build --target wasm32-wasi --release
-wasmedgec target/wasm32-wasi/release/wasmedge_hyper_server_tflite.wasm wasmedge_hyper_server_tflite.wasm
+cargo build --target wasm32-wasip1 --release
+wasmedgec target/wasm32-wasip1/release/wasmedge_hyper_server_tflite.wasm wasmedge_hyper_server_tflite.wasm
 ```
 
 Deploy.
@@ -103,8 +103,8 @@ Build.
 
 ```bash
 cd events-service
-cargo build --target wasm32-wasi --release
-wasmedgec target/wasm32-wasi/release/events_service.wasm events_service.wasm
+cargo build --target wasm32-wasip1 --release
+wasmedgec target/wasm32-wasip1/release/events_service.wasm events_service.wasm
 ```
 
 Deploy.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/develop/rust/database/my_sql_driver.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/develop/rust/database/my_sql_driver.md
@@ -21,10 +21,10 @@ git clone https://github.com/WasmEdge/wasmedge-db-examples
 cd wasmedge-db-examples/mysql_async
 
 # Compile the rust code into WASM
-RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasi --release
+RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasip1 --release
 
 # Execute MySQL statements against a MySQL database at mysql://user:passwd@127.0.0.1:3306
-wasmedge --env "DATABASE_URL=mysql://user:passwd@127.0.0.1:3306/mysql" target/wasm32-wasi/release/crud.wasm
+wasmedge --env "DATABASE_URL=mysql://user:passwd@127.0.0.1:3306/mysql" target/wasm32-wasip1/release/crud.wasm
 ```
 
 <!-- prettier-ignore -->

--- a/i18n/zh/docusaurus-plugin-content-docs/current/develop/rust/database/postgres_driver.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/develop/rust/database/postgres_driver.md
@@ -21,10 +21,10 @@ git clone https://github.com/WasmEdge/wasmedge-db-examples
 cd wasmedge-db-examples/postgres
 
 # Compile the rust code into WASM
-RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasi --release
+RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasip1 --release
 
 # Execute SQL statements against a PostgreSQL database at postgres://user:passwd@localhost/testdb
-wasmedge --env "DATABASE_URL=postgres://user:passwd@localhost/testdb" target/wasm32-wasi/release/crud.wasm
+wasmedge --env "DATABASE_URL=postgres://user:passwd@localhost/testdb" target/wasm32-wasip1/release/crud.wasm
 ```
 
 ## Configuration

--- a/i18n/zh/docusaurus-plugin-content-docs/current/develop/rust/database/qdrant_driver.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/develop/rust/database/qdrant_driver.md
@@ -23,10 +23,10 @@ git clone https://github.com/WasmEdge/wasmedge-db-examples
 cd wasmedge-db-examples/qdrant
 
 # Compile the rust code into WASM
-RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasi --release
+RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasip1 --release
 
 # Perform vector data operations against a Qdrant at http://localhost:6333
-wasmedge target/wasm32-wasi/release/qdrant_examples.wasm
+wasmedge target/wasm32-wasip1/release/qdrant_examples.wasm
 ```
 
 ## Configuration

--- a/i18n/zh/docusaurus-plugin-content-docs/current/develop/rust/database/redis_driver.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/develop/rust/database/redis_driver.md
@@ -21,10 +21,10 @@ git clone https://github.com/WasmEdge/wasmedge-db-examples
 cd wasmedge-db-examples/redis
 
 # Compile the rust code into WASM
-RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasi --release
+RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasip1 --release
 
 # Execute Redis command against a Redis instance at redis://localhost/
-wasmedge --env "REDIS_URL=redis://localhost/" target/wasm32-wasi/release/wasmedge-redis-client-examples.wasm
+wasmedge --env "REDIS_URL=redis://localhost/" target/wasm32-wasip1/release/wasmedge-redis-client-examples.wasm
 ```
 
 ## Configuration

--- a/i18n/zh/docusaurus-plugin-content-docs/current/develop/rust/hello_world.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/develop/rust/hello_world.md
@@ -20,13 +20,13 @@ fn main() {
 Build the WASM bytecode:
 
 ```bash
-cargo build --target wasm32-wasi --release
+cargo build --target wasm32-wasip1 --release
 ```
 
 We will use the `wasmedge` command to run the program.
 
 ```bash
-$ wasmedge target/wasm32-wasi/release/hello.wasm
+$ wasmedge target/wasm32-wasip1/release/hello.wasm
 Hello WasmEdge
 ```
 
@@ -48,7 +48,7 @@ pub fn add(a: i32, b: i32) -> i32 {
 ### Build the WASM bytecode
 
 ```bash
-cargo build --target wasm32-wasi --release
+cargo build --target wasm32-wasip1 --release
 ```
 
 ### Run the application from command line
@@ -56,7 +56,7 @@ cargo build --target wasm32-wasi --release
 We will use `wasmedge` in reactor mode to run the program. We pass the function name and its input parameters as command line arguments.
 
 ```bash
-$ wasmedge --reactor target/wasm32-wasi/release/add.wasm add 2 2
+$ wasmedge --reactor target/wasm32-wasip1/release/add.wasm add 2 2
 4
 ```
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/develop/rust/http_service/client.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/develop/rust/http_service/client.md
@@ -31,10 +31,10 @@ git clone https://github.com/WasmEdge/wasmedge_reqwest_demo
 cd wasmedge_reqwest_demo
 
 # Build the Rust code
-RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasi --release
+RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasip1 --release
 # Use the AoT compiler to get better performance
-wasmedge compile target/wasm32-wasi/release/http.wasm http.wasm
-wasmedge compile target/wasm32-wasi/release/https.wasm https.wasm
+wasmedge compile target/wasm32-wasip1/release/http.wasm http.wasm
+wasmedge compile target/wasm32-wasip1/release/https.wasm https.wasm
 
 # Run the HTTP GET and POST examples
 wasmedge http.wasm
@@ -102,9 +102,9 @@ git clone https://github.com/WasmEdge/wasmedge_hyper_demo
 cd wasmedge_hyper_demo/client
 
 # Build the Rust code
-RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasi --release
+RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasip1 --release
 # Use the AoT compiler to get better performance
-wasmedge compile target/wasm32-wasi/release/wasmedge_hyper_client.wasm wasmedge_hyper_client.wasm
+wasmedge compile target/wasm32-wasip1/release/wasmedge_hyper_client.wasm wasmedge_hyper_client.wasm
 
 # Run the example
 wasmedge wasmedge_hyper_client.wasm
@@ -130,8 +130,8 @@ The HTTPS version of the demo is as follows.
 ```bash
 // Build
 cd wasmedge_hyper_demo/client-https
-RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasi --release
-wasmedge compile target/wasm32-wasi/release/wasmedge_hyper_client_https.wasm wasmedge_hyper_client_https.wasm
+RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasip1 --release
+wasmedge compile target/wasm32-wasip1/release/wasmedge_hyper_client_https.wasm wasmedge_hyper_client_https.wasm
 
 // Run
 wasmedge wasmedge_hyper_client_https.wasm

--- a/i18n/zh/docusaurus-plugin-content-docs/current/develop/rust/http_service/server.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/develop/rust/http_service/server.md
@@ -27,9 +27,9 @@ git clone https://github.com/WasmEdge/wasmedge_hyper_demo
 cd wasmedge_hyper_demo/server-axum
 
 # Build the Rust code
-RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasi --release
+RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasip1 --release
 # Use the AoT compiler for better performance
-wasmedge compile target/wasm32-wasi/release/wasmedge_axum_server.wasm wasmedge_axum_server.wasm
+wasmedge compile target/wasm32-wasip1/release/wasmedge_axum_server.wasm wasmedge_axum_server.wasm
 
 # Run the example
 wasmedge wasmedge_axum_server.wasm
@@ -103,9 +103,9 @@ git clone https://github.com/WasmEdge/wasmedge_hyper_demo
 cd wasmedge_hyper_demo/server
 
 # Build the Rust code
-RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasi --release
+RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasip1 --release
 # Use the AoT compiler to get better performance
-wasmedge compile target/wasm32-wasi/release/wasmedge_hyper_server.wasm wasmedge_hyper_server.wasm
+wasmedge compile target/wasm32-wasip1/release/wasmedge_hyper_server.wasm wasmedge_hyper_server.wasm
 
 # Run the example
 wasmedge wasmedge_hyper_server.wasm

--- a/i18n/zh/docusaurus-plugin-content-docs/current/develop/rust/os.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/develop/rust/os.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # Access OS services
 
-The WASI (WebAssembly Systems Interface) standard is designed to allow WebAssembly applications to access operating system services. The `wasm32-wasi` target in the Rust compiler supports WASI. This section will use [an example project](https://github.com/second-state/rust-examples/tree/main/wasi) to show how to use Rust standard APIs to access operating system services.
+The WASI (WebAssembly Systems Interface) standard is designed to allow WebAssembly applications to access operating system services. The `wasm32-wasip1` target in the Rust compiler supports WASI. This section will use [an example project](https://github.com/second-state/rust-examples/tree/main/wasi) to show how to use Rust standard APIs to access operating system services.
 
 <!-- prettier-ignore -->
 :::note
@@ -13,7 +13,7 @@ Before we start, ensure [you have Rust and WasmEdge installed](setup.md).
 
 ## Random numbers
 
-The WebAssembly VM is a pure software construct. It does not have a hardware entropy source for random numbers. That's why WASI defines a function for WebAssembly programs to call its host operating system to get a random seed. As a Rust developer, you only need to use the popular (de facto standard) `rand` and/or `getrandom` crates. With the `wasm32-wasi` compiler backend, these crates generate the correct WASI calls in the WebAssembly bytecode. The `Cargo.toml` dependencies are as follows.
+The WebAssembly VM is a pure software construct. It does not have a hardware entropy source for random numbers. That's why WASI defines a function for WebAssembly programs to call its host operating system to get a random seed. As a Rust developer, you only need to use the popular (de facto standard) `rand` and/or `getrandom` crates. With the `wasm32-wasip1` compiler backend, these crates generate the correct WASI calls in the WebAssembly bytecode. The `Cargo.toml` dependencies are as follows.
 
 ```toml
 [dependencies]
@@ -117,13 +117,13 @@ fn main() {
 Use the command below to compile [the Rust project](https://github.com/second-state/rust-examples/blob/main/wasi/).
 
 ```bash
-cargo build --target wasm32-wasi --release
+cargo build --target wasm32-wasip1 --release
 ```
 
 To run it in `wasmedge`, do the following. The `--dir` option maps the current directory of the command shell to the file system's current directory inside the WebAssembly app.
 
 ```bash
-$ wasmedge --dir .:. target/wasm32-wasi/release/wasi.wasm
+$ wasmedge --dir .:. target/wasm32-wasip1/release/wasi.wasm
 Random number: -1157533356
 Random bytes: [159, 159, 9, 119, 106, 172, 207, 82, 173, 145, 233, 214, 104, 35, 23, 53, 155, 12, 102, 231, 117, 67, 192, 215, 207, 202, 128, 198, 213, 41, 235, 57, 89, 223, 138, 70, 185, 137, 74, 162, 42, 20, 226, 177, 114, 170, 172, 39, 149, 99, 122, 68, 115, 205, 155, 202, 4, 48, 178, 224, 124, 42, 24, 56, 215, 90, 203, 150, 106, 128, 127, 201, 177, 187, 20, 195, 172, 56, 72, 28, 53, 163, 59, 36, 129, 160, 69, 203, 196, 72, 113, 61, 46, 249, 81, 134, 94, 134, 159, 51, 233, 247, 253, 116, 202, 210, 100, 75, 74, 95, 197, 44, 81, 87, 89, 115, 20, 226, 143, 139, 50, 60, 196, 59, 206, 105, 161, 226]
 Printed from wasi: This is from a main function

--- a/i18n/zh/docusaurus-plugin-content-docs/current/develop/rust/setup.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/develop/rust/setup.md
@@ -26,10 +26,10 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 ## Set up the Rust compiler's target
 
-To build a WASM file running in server-side WebAssembly like WasmEdge, we need to add the `wasm32-wasi` target for the Rust compiler after Rust is installed.
+To build a WASM file running in server-side WebAssembly like WasmEdge, we need to add the `wasm32-wasip1` target for the Rust compiler after Rust is installed.
 
 ```bash
-rustup target add wasm32-wasi
+rustup target add wasm32-wasip1
 ```
 
 ## Special notes for networking apps
@@ -40,21 +40,21 @@ WasmEdge supports async networking APIs provided by [Tokio](https://tokio.rs/) a
 need to add a few config flags to help the Rust compiler choose the correct feature branches in the library source code. Here is an example of `cargo build` command for compiling a tokio app to Wasm.
 
 ```bash
-RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasi --release
+RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasip1 --release
 ```
 
 Alternatively, you could add these lines to the `.cargo/config.toml` file.
 
 ```toml
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"
 rustflags = ["--cfg", "wasmedge", "--cfg", "tokio_unstable"]
 ```
 
 Once you have these lines in `.cargo/config.toml`, you can simply use the regular `cargo` command.
 
 ```bash
-cargo build --target wasm32-wasi --release
+cargo build --target wasm32-wasip1 --release
 ```
 
 ### TLS on MacOS

--- a/i18n/zh/docusaurus-plugin-content-docs/current/develop/rust/socket_networking/client.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/develop/rust/socket_networking/client.md
@@ -25,9 +25,9 @@ git clone https://github.com/second-state/wasmedge_wasi_socket.git
 cd wasmedge_wasi_socket/http_client/
 
 # Build the Rust Code
-cargo build --target wasm32-wasi --release
+cargo build --target wasm32-wasip1 --release
 # Use the AoT compiler to get better performance
-wasmedge compile target/wasm32-wasi/release/http_client.wasm http_client.wasm
+wasmedge compile target/wasm32-wasip1/release/http_client.wasm http_client.wasm
 
 # Run the example
 wasmedge http_client.wasm
@@ -69,9 +69,9 @@ git clone https://github.com/second-state/wasmedge_wasi_socket
 cd wasmedge_wasi_socket/nonblock_http_client/
 
 # Build the Rust Code
-cargo build --target wasm32-wasi --release
+cargo build --target wasm32-wasip1 --release
 # Use the AoT compiler for better performance
-wasmedge compile target/wasm32-wasi/release/nonblock_http_client.wasm nonblock_http_client.wasm
+wasmedge compile target/wasm32-wasip1/release/nonblock_http_client.wasm nonblock_http_client.wasm
 
 # Run the example
 wasmedge nonblock_http_client.wasm

--- a/i18n/zh/docusaurus-plugin-content-docs/current/develop/rust/socket_networking/server.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/develop/rust/socket_networking/server.md
@@ -23,9 +23,9 @@ git clone https://github.com/second-state/wasmedge_wasi_socket
 cd wasmedge_wasi_socket/http_server
 
 # Build the Rust code
-cargo build --target wasm32-wasi --release
+cargo build --target wasm32-wasip1 --release
 # Use the AoT compiler for better performance
-wasmedge compile target/wasm32-wasi/release/http_server.wasm http_server.wasm
+wasmedge compile target/wasm32-wasip1/release/http_server.wasm http_server.wasm
 
 # Run the example
 $wasmedge http_server.wasm
@@ -117,9 +117,9 @@ git clone https://github.com/second-state/wasmedge_wasi_socket
 cd wasmedge_wasi_socket
 
 # Build the Rust code
-cargo build --target wasm32-wasi --release
+cargo build --target wasm32-wasip1 --release
 # Use the AoT compiler for better performance
-wasmedge compile target/wasm32-wasi/release/poll_tcp_listener.wasm poll_tcp_listener.wasm
+wasmedge compile target/wasm32-wasip1/release/poll_tcp_listener.wasm poll_tcp_listener.wasm
 
 # Run the example
 wasmedge poll_tcp_listener.wasm

--- a/i18n/zh/docusaurus-plugin-content-docs/current/develop/rust/ssr.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/develop/rust/ssr.md
@@ -36,7 +36,7 @@ wasm-bindgen = { git = "https://github.com/KernelErr/wasm-bindgen.git", branch =
 
 <!-- prettier-ignore -->
 :::note
-Why do we need a forked `wasm-bindgen`? That is because `wasm-bindgen` is the required glue between Rust and HTML in the browser. On the server, however, we need to build the Rust code to the `wasm32-wasi` target, which is incompatible with `wasm-bindgen`. Our forked `wasm-bindgen` has conditional configs that remove browser-specific code in the generated `.wasm` file for the `wasm32-wasi` target.
+Why do we need a forked `wasm-bindgen`? That is because `wasm-bindgen` is the required glue between Rust and HTML in the browser. On the server, however, we need to build the Rust code to the `wasm32-wasip1` target, which is incompatible with `wasm-bindgen`. Our forked `wasm-bindgen` has conditional configs that remove browser-specific code in the generated `.wasm` file for the `wasm32-wasip1` target.
 :::
 
 Then replace the crate's `Cargo.toml` with the following content.
@@ -304,8 +304,8 @@ Next, build and run the server.
 
 ```bash
 cd ../server-wasmedge
-cargo build --target wasm32-wasi
-OUTPUT_CSS="$(pwd)/../client/build/app.css" wasmedge --dir /static:../client/build ../../../target/wasm32-wasi/debug/isomorphic-server-wasmedge.wasm
+cargo build --target wasm32-wasip1
+OUTPUT_CSS="$(pwd)/../client/build/app.css" wasmedge --dir /static:../client/build ../../../target/wasm32-wasip1/debug/isomorphic-server-wasmedge.wasm
 ```
 
 Navigate to `http://127.0.0.1:3000`, and you will see the web application in action.
@@ -330,9 +330,9 @@ Add the following to the `.cargo/config.toml` file.
 
 ```toml
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"
 
-[target.wasm32-wasi]
+[target.wasm32-wasip1]
 runner = "wasmedge --dir /static:../client/build"
 ```
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/develop/rust/wasinn/llm_inference.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/develop/rust/wasinn/llm_inference.md
@@ -59,10 +59,10 @@ cd chat
 Second, use `cargo` to build the example project.
 
 ```bash
-cargo build --target wasm32-wasi --release
+cargo build --target wasm32-wasip1 --release
 ```
 
-The output WASM file is `target/wasm32-wasi/release/llama-chat.wasm`. Next, use WasmEdge to load the llama-3.1-8b model and then ask the model questions.
+The output WASM file is `target/wasm32-wasip1/release/llama-chat.wasm`. Next, use WasmEdge to load the llama-3.1-8b model and then ask the model questions.
 
 ```bash
 wasmedge --dir .:. --nn-preload default:GGML:AUTO:Meta-Llama-3.1-8B-Instruct-Q5_K_M.gguf llama-chat.wasm -p llama-3-chat

--- a/i18n/zh/docusaurus-plugin-content-docs/current/develop/rust/wasinn/mediapipe.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/develop/rust/wasinn/mediapipe.md
@@ -22,8 +22,8 @@ cd demo-object-detection/
 Build an inference application using the Mediapipe object detection model.
 
 ```bash
-cargo build --target wasm32-wasi --release
-wasmedge compile target/wasm32-wasi/release/demo-object-detection.wasm demo-object-detection.wasm
+cargo build --target wasm32-wasip1 --release
+wasmedge compile target/wasm32-wasip1/release/demo-object-detection.wasm demo-object-detection.wasm
 ```
 
 Run the inference application against an image. The input `example.jpg` image is shown below.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/develop/rust/wasinn/openvino.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/develop/rust/wasinn/openvino.md
@@ -55,10 +55,10 @@ cd WasmEdge-WASINN-examples/openvino-mobilenet-image/rust/
 Second, use `cargo` to build the template project.
 
 ```bash
-cargo build --target wasm32-wasi --release
+cargo build --target wasm32-wasip1 --release
 ```
 
-The output WASM file is `target/wasm32-wasi/release/wasmedge-wasinn-example-mobilenet-image.wasm`. Download the OpenVINO model files. Next, use WasmEdge to load the OpenVINO model and then use it to classify objects in your image.
+The output WASM file is `target/wasm32-wasip1/release/wasmedge-wasinn-example-mobilenet-image.wasm`. Download the OpenVINO model files. Next, use WasmEdge to load the OpenVINO model and then use it to classify objects in your image.
 
 ```bash
 ./download_mobilenet.sh

--- a/i18n/zh/docusaurus-plugin-content-docs/current/develop/rust/wasinn/pytorch.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/develop/rust/wasinn/pytorch.md
@@ -52,10 +52,10 @@ cd WasmEdge-WASINN-examples/pytorch-mobilenet-image/rust
 Second, use `cargo` to build the example project.
 
 ```bash
-cargo build --target wasm32-wasi --release
+cargo build --target wasm32-wasip1 --release
 ```
 
-The output WASM file is `target/wasm32-wasi/release/wasmedge-wasinn-example-mobilenet-image.wasm`. Next, use WasmEdge to load the PyTorch model and then use it to classify objects in your image.
+The output WASM file is `target/wasm32-wasip1/release/wasmedge-wasinn-example-mobilenet-image.wasm`. Next, use WasmEdge to load the PyTorch model and then use it to classify objects in your image.
 
 ```bash
 wasmedge --dir .:. wasmedge-wasinn-example-mobilenet-image.wasm mobilenet.pt input.jpg

--- a/i18n/zh/docusaurus-plugin-content-docs/current/develop/rust/wasinn/tensorflow_lite.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/develop/rust/wasinn/tensorflow_lite.md
@@ -52,10 +52,10 @@ cd WasmEdge-WASINN-examples/tflite-birds_v1-image/rust/
 Second, use `cargo` to build the example project.
 
 ```bash
-cargo build --target wasm32-wasi --release
+cargo build --target wasm32-wasip1 --release
 ```
 
-The output WASM file is `target/wasm32-wasi/release/wasmedge-wasinn-example-tflite-bird-image.wasm`. Next, let's use WasmEdge to load the Tensorflow Lite model and then use it to classify objects in your image.
+The output WASM file is `target/wasm32-wasip1/release/wasmedge-wasinn-example-tflite-bird-image.wasm`. Next, let's use WasmEdge to load the Tensorflow Lite model and then use it to classify objects in your image.
 
 ```bash
 wasmedge --dir .:. wasmedge-wasinn-example-tflite-bird-image.wasm lite-model_aiy_vision_classifier_birds_V1_3.tflite bird.jpg

--- a/i18n/zh/docusaurus-plugin-content-docs/current/develop/rust/wasinn/tf_plugin.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/develop/rust/wasinn/tf_plugin.md
@@ -125,10 +125,10 @@ let res_vec: Vec<f32> = session.get_output("MobilenetV2/Predictions/Softmax");
 After completing your code, you can follow the command to compile into WASM.
 
 ```bash
-cargo build --target=wasm32-wasi
+cargo build --target=wasm32-wasip1
 ```
 
-The output WASM file will be at `target/wasm32-wasi/debug/` or `target/wasm32-wasi/release`.
+The output WASM file will be at `target/wasm32-wasip1/debug/` or `target/wasm32-wasip1/release`.
 
 Please refer to [WasmEdge CLI](../../../start/build-and-run/cli.md) for WASM execution.
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/embed/go/ai.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/embed/go/ai.md
@@ -38,8 +38,8 @@ You can build the standard `Cargo` command into a WebAssembly function.
 ```bash
 git clone https://github.com/second-state/WasmEdge-go-examples.git
 cd go_TfliteFood/rust_tflite_food
-cargo build --target wasm32-wasi --release
-cp target/wasm32-wasi/release/rust_tflite_food_lib.wasm ../
+cargo build --target wasm32-wasip1 --release
+cp target/wasm32-wasip1/release/rust_tflite_food_lib.wasm ../
 cd ../
 ```
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/embed/go/app.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/embed/go/app.md
@@ -68,8 +68,8 @@ Next, let's compile the application into WebAssembly.
 ```bash
 git clone https://github.com/second-state/WasmEdge-go-examples.git
 cd rust_readfile
-cargo build --target wasm32-wasi
-# The output file will be target/wasm32-wasi/debug/rust_readfile.wasm
+cargo build --target wasm32-wasip1
+# The output file will be target/wasm32-wasip1/debug/rust_readfile.wasm
 ```
 
 ## The Go Host app
@@ -118,7 +118,7 @@ go build
 Run the Golang application.
 
 ```bash
-$ ./read_file rust_readfile/target/wasm32-wasi/debug/rust_readfile.wasm file.txt
+$ ./read_file rust_readfile/target/wasm32-wasip1/debug/rust_readfile.wasm file.txt
 Rust: Opening input file "file.txt"...
 Rust: Read input file "file.txt" succeeded.
 Rust: Please input the line number to print the line of file.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/embed/go/bindgen.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/embed/go/bindgen.md
@@ -93,8 +93,8 @@ First, we will compile the Rust source code into WebAssembly bytecode functions.
 ```bash
 git clone https://github.com/second-state/WasmEdge-go-examples.git
 cd rust_bindgen_funcs
-$cargo build --release --target wasm32-wasi
-# The output WASM will be target/wasm32-wasi/release/rust_bindgen_funcs_lib.wasm
+$cargo build --release --target wasm32-wasip1
+# The output WASM will be target/wasm32-wasip1/release/rust_bindgen_funcs_lib.wasm
 ```
 
 ## The Go host app
@@ -203,7 +203,7 @@ go build
 Run the Go application and it will run the WebAssembly functions embedded in the WasmEdge runtime.
 
 ```bash
-$ ./bindgen_funcs rust_bindgen_funcs/target/wasm32-wasi/release/rust_bindgen_funcs_lib.wasm
+$ ./bindgen_funcs rust_bindgen_funcs/target/wasm32-wasip1/release/rust_bindgen_funcs_lib.wasm
 Run bindgen -- create_line: {"points":[{"x":1.5,"y":3.8},{"x":2.5,"y":5.8}],"valid":true,"length":2.2360682,"desc":"A thin red line"}
 Run bindgen -- say: hello bindgen funcs test
 Run bindgen -- obfusticate: N dhvpx oebja sbk whzcf bire gur ynml qbt

--- a/i18n/zh/docusaurus-plugin-content-docs/current/embed/go/function.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/embed/go/function.md
@@ -93,8 +93,8 @@ First, we will compile the Rust source code into WebAssembly bytecode functions.
 ```bash
 git clone https://github.com/second-state/WasmEdge-go-examples.git
 cd rust_bindgen_funcs
-cargo build --release --target wasm32-wasi
-# The output WASM will be target/wasm32-wasi/release/rust_bindgen_funcs_lib.wasm
+cargo build --release --target wasm32-wasip1
+# The output WASM will be target/wasm32-wasip1/release/rust_bindgen_funcs_lib.wasm
 ```
 
 ## The Go host app
@@ -203,7 +203,7 @@ go build
 Run the Go application, and it will run the WebAssembly functions embedded in the WasmEdge runtime.
 
 ```bash
-$ ./bindgen_funcs rust_bindgen_funcs/target/wasm32-wasi/release/rust_bindgen_funcs_lib.wasm
+$ ./bindgen_funcs rust_bindgen_funcs/target/wasm32-wasip1/release/rust_bindgen_funcs_lib.wasm
 Run bindgen -- create_line: {"points":[{"x":1.5,"y":3.8},{"x":2.5,"y":5.8}],"valid":true,"length":2.2360682,"desc":"A thin red line"}
 Run bindgen -- say: hello bindgen funcs test
 Run bindgen -- obfusticate: N dhvpx oebja sbk whzcf bire gur ynml qbt

--- a/i18n/zh/docusaurus-plugin-content-docs/current/embed/go/passing_data.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/embed/go/passing_data.md
@@ -63,8 +63,8 @@ Use standard Rust compiler tools to compile the Rust source code into a WebAssem
 
 ```bash
 cd rust_memory_greet
-cargo build --target wasm32-wasi
-# The output WASM will be `target/wasm32-wasi/debug/rust_memory_greet_lib.wasm`.
+cargo build --target wasm32-wasip1
+# The output WASM will be `target/wasm32-wasip1/debug/rust_memory_greet_lib.wasm`.
 ```
 
 The [Go SDK application](https://github.com/second-state/WasmEdge-go-examples/blob/master/go_MemoryGreet/greet_memory.go) must call `allocate` from the WasmEdge VM to get a pointer to the string parameter. It will then call the `greet` function in Rust with the pointer. After the function returns, the Go application will call `deallocate` to free the memory space.
@@ -367,8 +367,8 @@ Use standard Rust compiler tools to compile the Rust source code into a WebAssem
 
 ```bash
 cd rust_access_memory
-cargo build --target wasm32-wasi
-# The output WASM will be target/wasm32-wasi/debug/rust_access_memory_lib.wasm.
+cargo build --target wasm32-wasip1
+# The output WASM will be target/wasm32-wasip1/debug/rust_access_memory_lib.wasm.
 ```
 
 The [Go SDK application](https://github.com/second-state/WasmEdge-go-examples/blob/master/go_AccessMemory/run.go) must call `allocate` from the WasmEdge VM to get a pointer to the array. It will then call the `fib_array()` function in Rust and pass in the pointer. After the functions return, the Go application will use the WasmEdge `store` API to construct an array from the pointer in the call parameter (`fib_array()`) or in the return value (`fib_array_return_memory()`). The Go app will eventually call `deallocate` to free the memory space.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/embed/go/reference/0.9.x.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/embed/go/reference/0.9.x.md
@@ -193,10 +193,10 @@ pub fn keccak_digest(s: Vec<u8>) -> Vec<u8> {
 First, compile the Rust source code into WebAssembly bytecode functions.
 
 ```bash
-rustup target add wasm32-wasi
+rustup target add wasm32-wasip1
 cd rust_bindgen_funcs
-cargo build --target wasm32-wasi --release
-# The output WASM will be target/wasm32-wasi/release/rust_bindgen_funcs_lib.wasm
+cargo build --target wasm32-wasip1 --release
+# The output WASM will be target/wasm32-wasip1/release/rust_bindgen_funcs_lib.wasm
 ```
 
 The [Golang source code](https://github.com/second-state/WasmEdge-go-examples/blob/master/wasmedge-bindgen/go_BindgenFuncs/bindgen_funcs.go) to run the WebAssembly function in WasmEdge is as follows. The `bg.Execute()` function calls the WebAssembly function and passes the parameters with the `wasmedge-bindgen` supporting.
@@ -305,7 +305,7 @@ go build
 Run the Golang application and it will run the WebAssembly functions embedded in the WasmEdge runtime.
 
 ```bash
-$ ./bindgen_funcs rust_bindgen_funcs/target/wasm32-wasi/release/rust_bindgen_funcs_lib.wasm
+$ ./bindgen_funcs rust_bindgen_funcs/target/wasm32-wasip1/release/rust_bindgen_funcs_lib.wasm
 Run bindgen -- create_line: {"points":[{"x":2.5,"y":7.8},{"x":2.5,"y":5.8}],"valid":true,"length":2.0,"desc":"A thin red line"}
 Run bindgen -- say: hello bindgen funcs test
 Run bindgen -- obfusticate: N dhvpx oebja sbk whzcf bire gur ynml qbt
@@ -385,10 +385,10 @@ Or you can compile the application into WebAssembly directly by `cargo`:
 
 ```bash
 cd rust_readfile
-# Need to add the `wasm32-wasi` target.
-rustup target add wasm32-wasi
-cargo build --release --target=wasm32-wasi
-# The output wasm will be at `target/wasm32-wasi/release/rust_readfile.wasm`.
+# Need to add the `wasm32-wasip1` target.
+rustup target add wasm32-wasip1
+cargo build --release --target=wasm32-wasip1
+# The output wasm will be at `target/wasm32-wasip1/release/rust_readfile.wasm`.
 ```
 
 The Golang source code to run the WebAssembly function in WasmEdge is as follows.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/embed/quick-start/wasm-app-in-rust.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/embed/quick-start/wasm-app-in-rust.md
@@ -13,7 +13,7 @@ The [wasmedge-bindgen](https://github.com/second-state/wasmedge-bindgen) project
 
 ## Prerequisites
 
-We need to install [Rust and add `wasm32-wasi` target for Rust](../../develop/rust/setup.md)
+We need to install [Rust and add `wasm32-wasip1` target for Rust](../../develop/rust/setup.md)
 
 We also need to install `wasmedge-bindgen`.
 
@@ -115,9 +115,9 @@ Next, build the WebAssembly bytecode file using standard `Cargo` commands.
 
 ```bash
 cd rust_bindgen_funcs
-cargo build --target wasm32-wasi --release
-# The output WASM will be target/wasm32-wasi/release/rust_bindgen_funcs_lib.wasm.
-cp target/wasm32-wasi/release/rust_bindgen_funcs_lib.wasm ../
+cargo build --target wasm32-wasip1 --release
+# The output WASM will be target/wasm32-wasip1/release/rust_bindgen_funcs_lib.wasm.
+cp target/wasm32-wasip1/release/rust_bindgen_funcs_lib.wasm ../
 cd ../
 ```
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/embed/use-case/libsql.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/embed/use-case/libsql.md
@@ -21,12 +21,12 @@ make
 
 ## The encrypt and decrypt example
 
-Build the encrypt and decrypt example into wasm. Since WasmEdge supports WASI functions here, we will use the `wasm32-wasi` target.
+Build the encrypt and decrypt example into wasm. Since WasmEdge supports WASI functions here, we will use the `wasm32-wasip1` target.
 
 ```bash
 git clone https://github.com/libsql/libsql_bindgen
 cd libsql_bindgen/examples/encrypt_decrypt
-cargo build --target wasm32-wasi --release
+cargo build --target wasm32-wasip1 --release
 ```
 
 Then, we can build a SQL file for creating the `encrypt` function in a libSQL database.
@@ -35,7 +35,7 @@ Then, we can build a SQL file for creating the `encrypt` function in a libSQL da
 export FUNC_NAME='encrypt'
 echo "DROP FUNCTION IF EXISTS ${FUNC_NAME};" >> create_${FUNC_NAME}_udf.sql
 echo -n "CREATE FUNCTION ${FUNC_NAME} LANGUAGE wasm AS X'" >> create_${FUNC_NAME}_udf.sql
-xxd -p  ../../target/wasm32-wasi/release/libsql_encrypt_decrypt.wasm | tr -d "\n" >> create_${FUNC_NAME}_udf.sql
+xxd -p  ../../target/wasm32-wasip1/release/libsql_encrypt_decrypt.wasm | tr -d "\n" >> create_${FUNC_NAME}_udf.sql
 echo "';" >> create_${FUNC_NAME}_udf.sql
 ```
 
@@ -45,7 +45,7 @@ Create another SQL file for the `decrypt` function.
 export FUNC_NAME='decrypt'
 echo "DROP FUNCTION IF EXISTS ${FUNC_NAME};" >> create_${FUNC_NAME}_udf.sql
 echo -n "CREATE FUNCTION ${FUNC_NAME} LANGUAGE wasm AS X'" >> create_${FUNC_NAME}_udf.sql
-xxd -p  ../../target/wasm32-wasi/release/libsql_encrypt_decrypt.wasm | tr -d "\n" >> create_${FUNC_NAME}_udf.sql
+xxd -p  ../../target/wasm32-wasip1/release/libsql_encrypt_decrypt.wasm | tr -d "\n" >> create_${FUNC_NAME}_udf.sql
 echo "';" >> create_${FUNC_NAME}_udf.sql
 ```
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/embed/use-case/wasm-nginx.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/embed/use-case/wasm-nginx.md
@@ -86,7 +86,7 @@ We also provide a Rust version (including Cargo.toml and others) [here](https://
 ### Rust Step 2: Build the corresponding WASM file
 
 ```shell
-cargo build --target=wasm32-wasi
+cargo build --target=wasm32-wasip1
 ```
 
 ### Rust Step 3: Load and execute the WASM file
@@ -107,7 +107,7 @@ http {
     init_by_lua_block {
         local wasm = require("resty.proxy-wasm")
         package.loaded.plugin = assert(wasm.load("fault_injection",
-            "/path/to/fault-injection/target/wasm32-wasi/debug/fault_injection.wasm"))
+            "/path/to/fault-injection/target/wasm32-wasip1/debug/fault_injection.wasm"))
     }
     server {
         listen 1980;

--- a/i18n/zh/docusaurus-plugin-content-docs/current/embed/use-case/yomo.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/embed/use-case/yomo.md
@@ -125,17 +125,17 @@ pub fn infer(image_data: Vec<u8>) -> Result<Vec<u8>, String> {
 }
 ```
 
-You should add `wasm32-wasi` target to rust to compile this function into WebAssembly bytecode.
+You should add `wasm32-wasip1` target to rust to compile this function into WebAssembly bytecode.
 
 ```bash
-rustup target add wasm32-wasi
+rustup target add wasm32-wasip1
 
 cd flow/rust_mobilenet_food
-cargo build --target wasm32-wasi --release
-# The output WASM will be target/wasm32-wasi/release/rust_mobilenet_food_lib.wasm
+cargo build --target wasm32-wasip1 --release
+# The output WASM will be target/wasm32-wasip1/release/rust_mobilenet_food_lib.wasm
 
 # Copy the wasm bytecode file to the flow/ directory
-cp target/wasm32-wasi/release/rust_mobilenet_food_lib.wasm ../
+cp target/wasm32-wasip1/release/rust_mobilenet_food_lib.wasm ../
 ```
 
 To release the best performance of WasmEdge, you should enable the AOT mode by compiling the `.wasm` file to the `.so`.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/start/build-and-run/cli.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/start/build-and-run/cli.md
@@ -101,13 +101,13 @@ Hello World 示例是一个独立的 Rust 应用程序，可以通过 [WasmEdge 
 你需要安装 [Rust 编译器](https://github.com/second-state/rust-examples/blob/main/README.md#prerequisites)，然后使用以下命令从 Rust 源代码构建 WASM 字节码文件。
 
 ```bash
-cargo build --target wasm32-wasi --release
+cargo build --target wasm32-wasip1 --release
 ```
 
 你可以使用 `wasmedge` 指令运行这个程序：
 
 ```bash
-$ wasmedge target/wasm32-wasi/release/hello.wasm
+$ wasmedge target/wasm32-wasip1/release/hello.wasm
 Hello WasmEdge!
 ```
 
@@ -190,7 +190,7 @@ Hello WasmEdge!
 你需要安装 [Rust 编译器](https://github.com/second-state/rust-examples/blob/main/README.md#prerequisites)，然后使用以下命令从 Rust 源代码构建 WASM 字节码文件。
 
 ```bash
-cargo build --target wasm32-wasi --release
+cargo build --target wasm32-wasip1 --release
 ```
 
 你可以在反应器模式下执行 `wasmedge`，以调用具有两个 `i32` 整数输入参数的 `add()` 函数。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/start/build-and-run/docker_wasm.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/start/build-and-run/docker_wasm.md
@@ -43,7 +43,7 @@ RUN <<EOT bash
     apt-get install -y \
         git \
         clang
-    rustup target add wasm32-wasi
+    rustup target add wasm32-wasip1
 EOT
 ```
 
@@ -54,7 +54,7 @@ FROM buildbase AS build
 COPY Cargo.toml .
 COPY src ./src
 # Build the WASM binary
-RUN cargo build --target wasm32-wasi --release
+RUN cargo build --target wasm32-wasip1 --release
 ```
 
 第三部分是关键部分。它将 WASM 文件复制到一个空的 `scratch` 容器中，然后将 WASM 文件设置为容器的 `ENTRYPOINT`。`rust-example-hello` 是由本节中的命令构建的容器镜像。
@@ -62,7 +62,7 @@ RUN cargo build --target wasm32-wasi --release
 ```dockerfile
 FROM scratch
 ENTRYPOINT [ "hello.wasm" ]
-COPY --link --from=build /src/target/wasm32-wasi/release/hello.wasm /hello.wasm
+COPY --link --from=build /src/target/wasm32-wasip1/release/hello.wasm /hello.wasm
 ```
 
 WASM 容器镜像仅为 0.5MB。它比最小 Linux 容器中原生编译的 Rust 程序要小得多。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/start/usage/serverless/aws.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/start/usage/serverless/aws.md
@@ -10,10 +10,10 @@ sidebar_position: 1
 
 ## 环境
 
-由于我们的演示 WebAssembly 函数是用 Rust 编写的，你需要安装 [Rust 编译器](https://www.rust-lang.org/tools/install)。确保你按照以下方式安装 `wasm32-wasi` 编译目标，以生成 WebAssembly 字节码。
+由于我们的演示 WebAssembly 函数是用 Rust 编写的，你需要安装 [Rust 编译器](https://www.rust-lang.org/tools/install)。确保你按照以下方式安装 `wasm32-wasip1` 编译目标，以生成 WebAssembly 字节码。
 
 ```bash
-rustup target add wasm32-wasi
+rustup target add wasm32-wasip1
 ```
 
 演示应用的前端是用 [Next.js](https://nextjs.org/) 编写的，并部署在 AWS Lambda 上。我们假设你已经对如何使用 Next.js 和 Lambda 有基本的了解。
@@ -58,13 +58,13 @@ fn main() {
 
 ```bash
 cd api/functions/image-grayscale/
-cargo build --release --target wasm32-wasi
+cargo build --release --target wasm32-wasip1
 ```
 
 将构建出结果复制到 `api` 文件夹。
 
 ```bash
-cp target/wasm32-wasi/release/grayscale.wasm ../../
+cp target/wasm32-wasip1/release/grayscale.wasm ../../
 ```
 
 > 在构建 Docker 镜像时，将执行 `api/pre.sh`。`pre.sh` 安装 WasmEdge 运行时，然后将每个 WebAssembly 字节码程序编译成本地 `so` 库，以实现更快的执行。
@@ -225,13 +225,13 @@ pub fn main() {
 
 ```bash
 cd api/functions/image-classification/
-cargo build --release --target wasm32-wasi
+cargo build --release --target wasm32-wasip1
 ```
 
 将构建产物复制到 `api` 文件夹。
 
 ```bash
-cp target/wasm32-wasi/release/classify.wasm ../../
+cp target/wasm32-wasip1/release/classify.wasm ../../
 ```
 
 同样，`api/pre.sh` 脚本在此应用程序中安装了 WasmEdge 运行时及其 TensorFlow 依赖项。它还在部署时将 `classify.wasm` 字节码程序编译为 `classify.so` 本机共享库。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/start/usage/serverless/netlify.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/start/usage/serverless/netlify.md
@@ -9,10 +9,10 @@ sidebar_position: 2
 
 ## 环境
 
-由于我们的演示 WebAssembly 函数是用 Rust 编写的，你将需要一个 [Rust 编译器](https://www.rust-lang.org/tools/install)。确保按照以下步骤安装 `wasm32-wasi` 编译目标，以便生成 WebAssembly 字节码。
+由于我们的演示 WebAssembly 函数是用 Rust 编写的，你将需要一个 [Rust 编译器](https://www.rust-lang.org/tools/install)。确保按照以下步骤安装 `wasm32-wasip1` 编译目标，以便生成 WebAssembly 字节码。
 
 ```bash
-rustup target add wasm32-wasi
+rustup target add wasm32-wasip1
 ```
 
 演示应用的前端是用 [Next.js](https://nextjs.org/) 编写的，并部署在 Netlify 上。我们假设你已经具备使用 Next.js 和 Netlify 的基本知识。
@@ -56,13 +56,13 @@ fn main() {
 
 ```bash
 cd api/functions/image-grayscale/
-cargo build --release --target wasm32-wasi
+cargo build --release --target wasm32-wasip1
 ```
 
 将构建产物复制到 `api` 文件夹。
 
 ```bash
-cp target/wasm32-wasi/release/grayscale.wasm ../../
+cp target/wasm32-wasip1/release/grayscale.wasm ../../
 ```
 
 > 在设置无服务器环境时，Netlify 函数会运行 [`api/pre.sh`](https://github.com/second-state/netlify-wasm-runtime/blob/main/api/pre.sh)。该脚本安装 WasmEdge 运行时，然后将每个 WebAssembly 字节码程序编译为本机 `so` 库，以实现更快的执行。
@@ -144,13 +144,13 @@ pub fn main() {
 
 ```bash
 cd api/functions/image-classification/
-cargo build --release --target wasm32-wasi
+cargo build --release --target wasm32-wasip1
 ```
 
 将构建产物复制到 `api` 文件夹中。
 
 ```bash
-cp target/wasm32-wasi/release/classify.wasm ../../
+cp target/wasm32-wasip1/release/classify.wasm ../../
 ```
 
 同样，[`api/pre.sh`](https://github.com/second-state/netlify-wasm-runtime/blob/tensorflow/api/pre.sh) 脚本在该应用程序中安装 WasmEdge 运行时及其 Tensorflow 依赖项。它还在部署时将 `classify.wasm` 字节码程序编译为 `classify.so` 本机共享库。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/start/usage/serverless/vercel.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/start/usage/serverless/vercel.md
@@ -10,10 +10,10 @@ sidebar_position: 5
 
 ## 环境
 
-由于我们的演示 WebAssembly 函数是用 Rust 编写的，你将需要 [Rust 编译器](https://www.rust-lang.org/tools/install)。确保你按照以下方式安装 `wasm32-wasi` 编译目标，以生成 WebAssembly 字节码。
+由于我们的演示 WebAssembly 函数是用 Rust 编写的，你将需要 [Rust 编译器](https://www.rust-lang.org/tools/install)。确保你按照以下方式安装 `wasm32-wasip1` 编译目标，以生成 WebAssembly 字节码。
 
 ```bash
-rustup target add wasm32-wasi
+rustup target add wasm32-wasip1
 ```
 
 演示应用的前端是用 [Next.js](https://nextjs.org/) 编写的，并部署在 Vercel 上。我们假设你对如何使用 Vercel 已经有基本的了解。
@@ -57,13 +57,13 @@ fn main() {
 
 ```bash
 cd api/functions/image-grayscale/
-cargo build --release --target wasm32-wasi
+cargo build --release --target wasm32-wasip1
 ```
 
 将构建产物复制到 `api` 文件夹。
 
 ```bash
-cp target/wasm32-wasi/release/grayscale.wasm ../../
+cp target/wasm32-wasip1/release/grayscale.wasm ../../
 ```
 
 > 在构建 Docker 镜像时，将执行 `api/pre.sh`。`pre.sh` 安装 WasmEdge 运行时，然后将每个 WebAssembly 字节码程序编译成本地 `so` 库，以实现更快的执行。
@@ -149,13 +149,13 @@ pub fn main() {
 
 ```bash
 cd api/functions/image-classification/
-cargo build --release --target wasm32-wasi
+cargo build --release --target wasm32-wasip1
 ```
 
 将构建产物复制到 `api` 文件夹。
 
 ```bash
-cp target/wasm32-wasi/release/classify.wasm ../../
+cp target/wasm32-wasip1/release/classify.wasm ../../
 ```
 
 同样，`api/pre.sh` 脚本在此应用程序中安装了 WasmEdge 运行时及其 TensorFlow 依赖项。它还在部署时将 `classify.wasm` 字节码程序编译为 `classify.so` 本机共享库。


### PR DESCRIPTION

Use `wasm32-wasip1` instead of `wasm32-wasi` because the `wasm32-wasi` target is being renamed to `wasm32-wasip1` and the `wasm32-wasi` target will be removed from nightly in October 2024 and removed from stable Rust in January 2025.