### PR TITLE
Include lld as a required package

### DIFF
--- a/docs/contribute/source/os/macos.md
+++ b/docs/contribute/source/os/macos.md
@@ -32,7 +32,7 @@ WasmEdge will try to use the latest LLVM release to create our nightly build. If
 
 ```bash
 # Tools and libraries
-brew install cmake ninja llvm
+brew install cmake ninja lld llvm
 export LLVM_DIR="$(brew --prefix)/opt/llvm/lib/cmake"
 export CC=clang
 export CXX=clang++


### PR DESCRIPTION
## Explanation

Without it, I get this error:

```
CMake Error at lib/llvm/CMakeLists.txt:11 (find_package):
  Could not find a package configuration file provided by "LLD" with any of
  the following names:

    LLDConfig.cmake
    lld-config.cmake

  Add the installation prefix of "LLD" to CMAKE_PREFIX_PATH or set "LLD_DIR"
  to a directory containing one of the above files.  If "LLD" provides a
  separate development package or SDK, be sure it has been installed.
```


## What type of PR is this

/kind documentation
