### PR TITLE
docs: no longer provide prebuilt blas version of llama.cpp plugin

### DIFF
--- a/docs/contribute/source/plugin/wasi_nn.md
+++ b/docs/contribute/source/plugin/wasi_nn.md
@@ -352,8 +352,6 @@ We also provided the pre-built ggml plugins on the following platforms:
 - darwin\_arm64: Apple Silicon Model macOS
 - ubuntu20.04\_x86\_64: x86\_64 Linux (the glibc is using Ubuntu20.04 one)
 - ubuntu20.04\_aarch64: aarch64 Linux (the glibc is using Ubuntu20.04 one)
-- ubuntu20.04\_blas\_x86\_64: x86\_64 Linux with OpenBLAS support (the glibc is using Ubuntu20.04 one)
-- ubuntu20.04\_blas\_aarch64: aarch64 Linux with OpenBLAS support (the glibc is using Ubuntu20.04 one)
 - ubuntu20.04\_cuda\_x86\_64: x86\_64 Linux with CUDA 12 support (the glibc is using Ubuntu20.04 one)
 - ubuntu20.04\_cuda\_aarch64: aarch64 Linux with CUDA 11 support (the glibc is using Ubuntu20.04 one), for NVIDIA Jetson AGX Orin
 - manylinux2014\_x86\_64: x86\_64 Linux (the glibc is using CentOS 7 one)

--- a/docs/start/install.md
+++ b/docs/start/install.md
@@ -202,7 +202,7 @@ winget uninstall wasmedge
 
 The installer from WasmEdge 0.13.5 will detect CUDA automatically. If CUDA is detected, the installer will always attempt to install a CUDA-enabled version of the WASI-NN GGML plug-in.
 
-If CPU is the only available hardware on your machine, the installer will install OpenBLAS version of plugin instead.
+If CPU is the only available hardware on your machine, the installer will install the pure CPU version of plugin instead.
 
 ```bash
 apt update && apt install -y libopenblas-dev # You may need sudo if the user is not root.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/contribute/source/plugin/wasi_nn.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/contribute/source/plugin/wasi_nn.md
@@ -352,8 +352,6 @@ We also provided the pre-built ggml plugins on the following platforms:
 - darwin\_arm64: Apple Silicon Model macOS
 - ubuntu20.04\_x86\_64: x86\_64 Linux (the glibc is using Ubuntu20.04 one)
 - ubuntu20.04\_aarch64: aarch64 Linux (the glibc is using Ubuntu20.04 one)
-- ubuntu20.04\_blas\_x86\_64: x86\_64 Linux with OpenBLAS support (the glibc is using Ubuntu20.04 one)
-- ubuntu20.04\_blas\_aarch64: aarch64 Linux with OpenBLAS support (the glibc is using Ubuntu20.04 one)
 - ubuntu20.04\_cuda\_x86\_64: x86\_64 Linux with CUDA 12 support (the glibc is using Ubuntu20.04 one)
 - ubuntu20.04\_cuda\_aarch64: aarch64 Linux with CUDA 11 support (the glibc is using Ubuntu20.04 one), for NVIDIA Jetson AGX Orin
 - manylinux2014\_x86\_64: x86\_64 Linux (the glibc is using CentOS 7 one)

--- a/i18n/zh/docusaurus-plugin-content-docs/current/start/install.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/start/install.md
@@ -158,7 +158,7 @@ WasmEdge 支持多种 `WASI-NN` 的后端。
 
 注意，WasmEdge 0.13.5 的安装程序将自动检测 CUDA。如果检测到 CUDA，安装程序将始终尝试安装支持 CUDA 的插件版本。
 
-如果您的机器上只有CPU可用，那么需要安装 OpenBLAS 版本的插件。
+如果您的机器上只有CPU可用，那么只會安裝 CPU 版本的插件。
 
 ```
 apt update && apt install -y libopenblas-dev # You may need sudo if the user is not root.


### PR DESCRIPTION
## Explanation

We no longer provide the prebuilt OpenBLAS version of the llama.cpp plugin.

## Related issue

## What type of PR is this

/kind documentation

## Proposed Changes

Remove related sections.