### PR TITLE
(docs): update outdated macos build from source docs

### DIFF
--- a/docs/contribute/source/os/macos.md
+++ b/docs/contribute/source/os/macos.md
@@ -28,12 +28,12 @@ cd WasmEdge
 
 WasmEdge will try to use the latest LLVM release to create our nightly build. If you want to build from source, you may need to install these dependencies yourself.
 
-- LLVM 16.0.4 (>= 10.0.0)
+- LLVM 18.1.8 (>= 10.0.0)
 
 ```bash
 # Tools and libraries
-brew install cmake ninja llvm@16
-export LLVM_DIR="$(brew --prefix)/opt/llvm@16/lib/cmake"
+brew install cmake ninja llvm@18
+export LLVM_DIR="$(brew --prefix)/opt/llvm@18/lib/cmake"
 export CC=clang
 export CXX=clang++
 ```

--- a/docs/contribute/source/os/macos.md
+++ b/docs/contribute/source/os/macos.md
@@ -32,8 +32,8 @@ WasmEdge will try to use the latest LLVM release to create our nightly build. If
 
 ```bash
 # Tools and libraries
-brew install cmake ninja llvm
-export LLVM_DIR="$(brew --prefix)/opt/llvm/lib/cmake"
+brew install cmake ninja llvm@16
+export LLVM_DIR="$(brew --prefix)/opt/llvm@16/lib/cmake"
 export CC=clang
 export CXX=clang++
 ```
@@ -59,11 +59,3 @@ Users can use these tests to verify the correctness of WasmEdge binaries.
 cd build
 DYLD_LIBRARY_PATH=$(pwd)/lib/api ctest
 ```
-
-## Known issues
-
-The following tests can not pass on Macos, we are investigating these issues:
-
-- wasmedgeWasiSocketTests
-
-But we have an open issue working on it. Don't hesitate to leave your feedback for [this issue](https://github.com/WasmEdge/WasmEdge/issues/2438).


### PR DESCRIPTION
## Explanation

This PR updates the outdated macOS build instructions page to reflect the current LLVM installation path used via Homebrew (llvm@16) and removes a deprecated section Known issues (since the issue has been resolved and there are no currently known issues).

## Related issue
None

## Motivation

While working on a separate PR, I noticed that the macOS build instructions were outdated and caused build failures. Specifically, the current instructions rely on `brew install llvm`, which now installs LLVM 20 by default. LLVM 20 has a different header structure especially for `lld`which breaks the build with errors like:

```
fatal error: 'lld/Common/Driver.h' file not found
```

To fix this, users would need to install `lld` separately and manually update include paths, which complicates the setup. However, using `llvm@16` avoids these issues because its layout matches the expectations of the WasmEdge build system (e.g., it places `lld/Common/Driver.h` under `$LLVM_DIR/include`).

This PR updates the instructions to use `llvm@16`, ensuring a smoother and consistent build experience on macOS.

## What type of PR is this

/kind documentation

## Proposed Changes

* Updated the macOS build instructions to explicitly install `llvm@16` via Homebrew (`brew install cmake ninja llvm@16`) to avoid compatibility issues introduced by LLVM 20.
* Updated the `LLVM_DIR` export path to match the location of `llvm@16` CMake files:
  `export LLVM_DIR="$(brew --prefix)/opt/llvm@16/lib/cmake"`.
* Removed the deprecated "Known issues" section, as the referenced macOS-specific test failure (`wasmedgeWasiSocketTests`) has been resolved.