### PR TITLE
docs: add missing part for the c plugin

### DIFF
--- a/docs/contribute/plugin/develop_plugin_c.md
+++ b/docs/contribute/plugin/develop_plugin_c.md
@@ -186,6 +186,12 @@ WasmEdge_Result HostFuncSub(void *Data,
       /* Pointer to the plug-in option description array (Work in progress). */
       .ProgramOptions = NULL,
   }};
+
+  /* Ensure the Plugin Descriptor is exported */
+  WASMEDGE_CAPI_PLUGIN_EXPORT const WasmEdge_PluginDescriptor *
+  WasmEdge_Plugin_GetDescriptor(void) {
+    return &Desc;
+  }
   ```
 
   These descriptions define the name, description, version, and creation function of the plug-in and the name and description of the module it contains.


### PR DESCRIPTION
## Explanation

Replace #216.

## Related issue

Fixes https://github.com/WasmEdge/WasmEdge/issues/3122

## What type of PR is this

/kind documentation

## Proposed Changes

Add missing part from [the simple example](https://github.com/WasmEdge/WasmEdge/blob/master/test/plugins/unittest/testplugin.c)