### PR TITLE
fix(docs): replace curl command with PowerShell-compatible Invoke-WebRequest

### DIFF
--- a/docs/contribute/source/os/windows.md
+++ b/docs/contribute/source/os/windows.md
@@ -39,7 +39,7 @@ Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments 
 
 # Download our pre-built LLVM 16 binary
 $llvm = "LLVM-16.0.6-win64-MultiThreadedDLL.zip"
-curl -sLO https://github.com/WasmEdge/llvm-windows/releases/download/llvmorg-16.0.6/LLVM-16.0.6-win64-MultiThreadedDLL.zip -o $llvm
+Invoke-WebRequest -Uri https://github.com/WasmEdge/llvm-windows/releases/download/llvmorg-16.0.6/LLVM-16.0.6-win64-MultiThreadedDLL.zip -OutFile $llvm
 Expand-Archive -Path $llvm
 
 # Set LLVM environment


### PR DESCRIPTION
## Explanation

The current Windows build instructions for WasmEdge recommend using the curl -sLO command to download LLVM. However, this command fails in PowerShell because Windows aliases curl to PowerShell's Invoke-WebRequest, which does not support the -sLO flags. This PR updates the instructions with a PowerShell-compatible command to ensure smooth downloads on Windows, improving the developer experience.

## Related issue

Closes: https://github.com/WasmEdge/www/issues/31

## What type of PR is this

> /kind documentation


## Proposed Changes

- Replaced the curl -sLO command in Windows build instructions with a PowerShell-compatible Invoke-WebRequest command.