### PR TITLE
docs: add build instructions for s390x

### DIFF
--- a/docs/contribute/source/build_from_src.md
+++ b/docs/contribute/source/build_from_src.md
@@ -15,6 +15,7 @@ Please follow this guide to build and test WasmEdge from the source code.
 - [OpenHarmony](os/openharmony.md)
 - [seL4](os/sel4)
 - [Raspberry Pi](os/raspberrypi.md)
+- [S390x](os/s390x.md)
 
 <!-- prettier-ignore -->
 :::note

--- a/docs/contribute/source/os/s390x.md
+++ b/docs/contribute/source/os/s390x.md
@@ -1,0 +1,74 @@
+---
+sidebar_position: 10
+---
+
+# Build on IBM LinuxONE(s390x)
+
+Please follow this tutorial to build and test WasmEdge on s390x hardware from source code.
+
+## Build WasmEdge
+
+### Get Source code
+
+```bash
+linux1@wasmedge:~$ git clone https://github.com/WasmEdge/WasmEdge.git
+```
+
+### Dependencies
+
+WasmEdge requires LLVM 18 at least and you may need to install the following dependencies yourself.
+
+:::note
+As Ubuntu 22.04 and previous versions of Ubuntu do not include the llvm-18 package, you can instead use the official llvm repository to install llvm-18.
+
+```bash
+wget https://apt.llvm.org/llvm.sh
+chmod +x llvm.sh
+sudo ./llvm.sh 18
+```
+:::
+
+```bash
+linux1@wasmedge:~$ sudo apt-get update
+linux1@wasmedge:~$ sudo apt install -y software-properties-common cmake gcc g++
+linux1@wasmedge:~$ sudo apt install -y llvm-18-dev liblld-18-dev
+```
+
+### Compile
+
+Please refer to [here](../build_from_src.md#cmake-building-options) for the descriptions of all CMake options.
+
+```bash
+linux1@wasmedge:~$ cd WasmEdge
+linux1@wasmedge:~/WasmEdge$ mkdir -p build && cd build
+linux1@wasmedge:~/WasmEdge/build$ cmake -DCMAKE_BUILD_TYPE=Release .. && make -j
+```
+
+## Run Tests
+
+The following tests are available only when the build option `WASMEDGE_BUILD_TESTS` is set to `ON`.
+
+Users can use these tests to verify the correctness of WasmEdge binaries.
+
+```bash
+cd <path/to/wasmedge/build_folder>
+LD_LIBRARY_PATH=$(pwd)/lib/api ctest
+```
+
+## Building Supported Plugins
+Currently, the [WASI-NN plugin](../plugin/wasi_nn#build-with-llamacpp-backend-on-linux) is supported on s390x, using the GGML backend.
+Building the plugin with BLAS support is recommended. to build the plugin with BLAS support, first install the OpenBLAS library:
+
+```bash
+linux1@wasmedge:~$ sudo apt install libopenblas-dev
+```
+
+Then, build WasmEdge with the following commands:
+
+```bash
+linux1@wasmedge:~$ cd <path/to/wasmedge/build_folder>
+linux1@wasmedge:~/WasmEdge/build$ make -DCMAKE_BUILD_TYPE=Release -DWASMEDGE_BUILD_PLUGINS=ON -DWASMEDGE_PLUGIN_WASI_NN_BACKEND="GGML" -DWASMEDGE_PLUGIN_WASI_NN_GGML_LLAMA_BLAS=ON ..
+```
+
+A guide on converting models to big endian is available at https://github.com/ggml-org/llama.cpp/blob/master/docs/build-s390x.md#getting-gguf-models
+

--- a/docs/start/wasmedge/features.md
+++ b/docs/start/wasmedge/features.md
@@ -64,6 +64,7 @@ WasmEdge now supports:
 - [OpenHarmony](../../contribute/source/os/openharmony.md)
 - [Raspberry Pi](../../contribute/source/os/raspberrypi.md)
 - [RISC-V (WIP)](../../contribute/source/os/riscv64.md)
+- [S390x](../../contribute/source/os/s390x.md)
 
 ## Easy extensible
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/contribute/source/build_from_src.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/contribute/source/build_from_src.md
@@ -15,6 +15,7 @@ Please follow this guide to build and test WasmEdge from the source code.
 - [OpenHarmony](os/openharmony.md)
 - [seL4](os/sel4)
 - [Raspberry Pi](os/raspberrypi.md)
+- [S390x](os/s390x.md)
 
 <!-- prettier-ignore -->
 :::note

--- a/i18n/zh/docusaurus-plugin-content-docs/current/contribute/source/os/s390x.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/contribute/source/os/s390x.md
@@ -1,0 +1,74 @@
+---
+sidebar_position: 10
+---
+
+# Build on IBM LinuxONE(s390x)
+
+Please follow this tutorial to build and test WasmEdge on s390x hardware from source code.
+
+## Build WasmEdge
+
+### Get Source code
+
+```bash
+linux1@wasmedge:~$ git clone https://github.com/WasmEdge/WasmEdge.git
+```
+
+### Dependencies
+
+WasmEdge requires LLVM 18 at least and you may need to install the following dependencies yourself.
+
+:::note
+As Ubuntu 22.04 and previous versions of Ubuntu do not include the llvm-18 package, you can instead use the official llvm repository to install llvm-18.
+
+```bash
+wget https://apt.llvm.org/llvm.sh
+chmod +x llvm.sh
+sudo ./llvm.sh 18
+```
+:::
+
+```bash
+linux1@wasmedge:~$ sudo apt-get update
+linux1@wasmedge:~$ sudo apt install -y software-properties-common cmake gcc g++
+linux1@wasmedge:~$ sudo apt install -y llvm-18-dev liblld-18-dev
+```
+
+### Compile
+
+Please refer to [here](../build_from_src.md#cmake-building-options) for the descriptions of all CMake options.
+
+```bash
+linux1@wasmedge:~$ cd WasmEdge
+linux1@wasmedge:~/WasmEdge$ mkdir -p build && cd build
+linux1@wasmedge:~/WasmEdge/build$ cmake -DCMAKE_BUILD_TYPE=Release .. && make -j
+```
+
+## Run Tests
+
+The following tests are available only when the build option `WASMEDGE_BUILD_TESTS` is set to `ON`.
+
+Users can use these tests to verify the correctness of WasmEdge binaries.
+
+```bash
+cd <path/to/wasmedge/build_folder>
+LD_LIBRARY_PATH=$(pwd)/lib/api ctest
+```
+
+## Building Supported Plugins
+Currently, the [WASI-NN plugin](../plugin/wasi_nn#build-with-llamacpp-backend-on-linux) is supported on s390x, using the GGML backend.
+Building the plugin with BLAS support is recommended. to build the plugin with BLAS support, first install the OpenBLAS library:
+
+```bash
+linux1@wasmedge:~$ sudo apt install libopenblas-dev
+```
+
+Then, build WasmEdge with the following commands:
+
+```bash
+linux1@wasmedge:~$ cd <path/to/wasmedge/build_folder>
+linux1@wasmedge:~/WasmEdge/build$ make -DCMAKE_BUILD_TYPE=Release -DWASMEDGE_BUILD_PLUGINS=ON -DWASMEDGE_PLUGIN_WASI_NN_BACKEND="GGML" -DWASMEDGE_PLUGIN_WASI_NN_GGML_LLAMA_BLAS=ON ..
+```
+
+A guide on converting models to big endian is available at https://github.com/ggml-org/llama.cpp/blob/master/docs/build-s390x.md#getting-gguf-models
+

--- a/i18n/zh/docusaurus-plugin-content-docs/current/start/wasmedge/features.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/start/wasmedge/features.md
@@ -64,6 +64,7 @@ WasmEdge 目前支持：
 - [OpenHarmony](../../contribute/source/os/openharmony.md)
 - [Raspberry Pi](../../contribute/source/os/raspberrypi.md)
 - [RISC-V(WIP)](../../contribute/source/os/riscv64.md)
+- [S390x](../../contribute/source/os/s390x.md)
 
 ## 易于扩展
 


### PR DESCRIPTION
## Explanation
This PR adds documentation for building and testing on the s390x platform.

Blocked by: https://github.com/WasmEdge/WasmEdge/pull/4251