### PR TITLE
Docs/fix build wasmedge from source 282

### DIFF
--- a/docs/contribute/contribute.md
+++ b/docs/contribute/contribute.md
@@ -116,7 +116,7 @@ Our development environment requires `libLLVM-12` and `>=GLIBCXX_3.4.26`.
 
 If you use an operating system older than Ubuntu 20.04, please use our [special docker image] to build WasmEdge. If you are looking for the pre-built binaries for the older operating system, we also provide several pre-built binaries based on the `manylinux2014` distribution.
 
-To build WasmEdge from the source, please refer to: [Build WasmEdge from source](/category/build-wasmedge-from-source).
+To build WasmEdge from the source, please refer to: [Build WasmEdge from source](/docs/contribute/source/build_from_src).
 
 ## Commit Format
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/contribute/contribute.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/contribute/contribute.md
@@ -116,7 +116,7 @@ Our development environment requires `libLLVM-12` and `>=GLIBCXX_3.4.26`.
 
 If you use an operating system older than Ubuntu 20.04, please use our [special docker image] to build WasmEdge. If you are looking for the pre-built binaries for the older operating system, we also provide several pre-built binaries based on the `manylinux2014` distribution.
 
-To build WasmEdge from the source, please refer to: [Build WasmEdge from source](/category/build-wasmedge-from-source).
+To build WasmEdge from the source, please refer to: [Build WasmEdge from source](/docs/contribute/source/build_from_src).
 
 ## Sign Your Commits
 


### PR DESCRIPTION
### Fixes #282

- Fixed broken documentation link
- Updated to correct Docusaurus route
- Documentation-only change

https://github.com/user-attachments/assets/564d2392-0c98-4bf7-ac60-284d7060de5a



