### PR TITLE
Fix broken build from source link

### DIFF
--- a/docs/contribute/contribute.md
+++ b/docs/contribute/contribute.md
@@ -116,7 +116,8 @@ Our development environment requires `libLLVM-12` and `>=GLIBCXX_3.4.26`.
 
 If you use an operating system older than Ubuntu 20.04, please use our [special docker image] to build WasmEdge. If you are looking for the pre-built binaries for the older operating system, we also provide several pre-built binaries based on the `manylinux2014` distribution.
 
-To build WasmEdge from the source, please refer to: [Build WasmEdge from source](/category/build-wasmedge-from-source).
+To build WasmEdge from the source, please refer to: [Build WasmEdge from source](/contribute/source/build_from_src
+).
 
 ## Commit Format
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/contribute/contribute.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/contribute/contribute.md
@@ -116,7 +116,7 @@ Our development environment requires `libLLVM-12` and `>=GLIBCXX_3.4.26`.
 
 If you use an operating system older than Ubuntu 20.04, please use our [special docker image] to build WasmEdge. If you are looking for the pre-built binaries for the older operating system, we also provide several pre-built binaries based on the `manylinux2014` distribution.
 
-To build WasmEdge from the source, please refer to: [Build WasmEdge from source](/category/build-wasmedge-from-source).
+To build WasmEdge from the source, please refer to: [Build WasmEdge from source](/contribute/source/build_from_src).
 
 ## Sign Your Commits
 


### PR DESCRIPTION
## Explanation

This PR fixes a broken documentation link in the Contribute guide.

It replaces a category-based link with a direct link to the correct documentation page and applies the fix in both English and Chinese (zh) versions to ensure consistent navigation across locales.

---

## Related issue

Fixes #282

---

## What type of PR is this

/kind documentation

---

## Proposed Changes

- Replaced the category-based link (`/category/build-wasmedge-from-source`) with a stable direct documentation link (`/contribute/source/build_from_src`)
- Updated the link in both English and zh documentation files
- Corrected the Docusaurus route to avoid invalid category links
- Documentation-only change 


https://github.com/user-attachments/assets/573f6bb2-0883-4766-bf5f-db6c36a7e8f6




