### PR TITLE
i18n(zh-Hans): added Simplified Chinese translations

### DIFF
--- a/i18n/zh/docusaurus-theme-classic/footer.json
+++ b/i18n/zh/docusaurus-theme-classic/footer.json
@@ -1,22 +1,22 @@
 {
   "link.title.Docs": {
-    "message": "Docs",
+    "message": "文档",
     "description": "The title of the footer links column with title=Docs in the footer"
   },
   "link.title.Community": {
-    "message": "Community",
+    "message": "社区",
     "description": "The title of the footer links column with title=Community in the footer"
   },
   "link.item.label.Develop": {
-    "message": "Develop",
+    "message": "发展",
     "description": "The label of footer link with label=Develop linking to /develop/overview"
   },
   "link.item.label.Embed": {
-    "message": "Embed",
+    "message": "嵌入",
     "description": "The label of footer link with label=Embed linking to /embed/overview"
   },
   "link.item.label.Extend": {
-    "message": "Extend",
+    "message": "延长",
     "description": "The label of footer link with label=Extend linking to /contribute/overview"
   },
   "link.item.label.Discord": {
@@ -28,7 +28,7 @@
     "description": "The label of footer link with label=Twitter linking to https://twitter.com/realwasmedge"
   },
   "copyright": {
-    "message": "Copyright © 2023 WasmEdge. Built with Docusaurus.",
+    "message": "版权所有 © 2023 WasmEdge。使用 Docusaurus 构建。",
     "description": "The footer copyright"
   }
 }

--- a/i18n/zh/docusaurus-theme-classic/navbar.json
+++ b/i18n/zh/docusaurus-theme-classic/navbar.json
@@ -4,15 +4,15 @@
     "description": "The title in the navbar"
   },
   "item.label.Develop": {
-    "message": "Develop",
+    "message": "发展",
     "description": "Navbar item with label Develop"
   },
   "item.label.Embed": {
-    "message": "Embed",
+    "message": "嵌入",
     "description": "Navbar item with label Embed"
   },
   "item.label.Extend": {
-    "message": "Extend",
+    "message": "延长",
     "description": "Navbar item with label Extend"
   },
   "item.label.GitHub": {


### PR DESCRIPTION
## Explaination
This PR adds Simplified Chinese (zh-Hans) translations to improve accessibility for Chinese-speaking users.
## What type of PR is this

/kind documentation

## Changes
- Added Simplified Chinese translations for footer UI labels
- Added Simplified Chinese translations for navbar UI labels
- Ensured consistent terminology across translated UI elements
- Followed existing Docusaurus i18n conventions

## Notes
- Brand names (e.g. Discord, Twitter/X) are kept untranslated
- No functional or behavioral changes are introduced
- Changes were tested by switching the site language to 简体中文


