### PR TITLE
develop/deploy: change crun/youki wording in intro

### DIFF
--- a/docs/develop/deploy/intro.md
+++ b/docs/develop/deploy/intro.md
@@ -10,7 +10,7 @@ Several options exist to manage WASM apps as “containers” under Kubernetes. 
 
 ## With containerd-shim
 
-**Option #1:** is to use a containerd-shim to start WASM "containers" via runwasi. Basically containerd could look at the image’s target platform. It uses runwasi if the image is wasm32 and runc if it is x86 / arm. Currently, Docker and Microsoft prefer this approach, which is also the basis for the [Docker + WASM preview](https://www.docker.com/blog/docker-wasm-technical-preview/). Based on containerd
+Option #1 is to use a containerd-shim to start WASM "containers" via runwasi. Basically containerd could look at the image’s target platform. It uses runwasi if the image is wasm32 and runc if it is x86 / arm. Currently, Docker and Microsoft prefer this approach, which is also the basis for the [Docker + WASM preview](https://www.docker.com/blog/docker-wasm-technical-preview/). Based on containerd
 
 The following image shows how it works.
 
@@ -18,11 +18,11 @@ The following image shows how it works.
 
 ## With crun
 
-Option #2 is to use an OCI runtime called crun (the C version of runc, mainly supported by Red Hat). crun decides whether an OCI image is wasm or Linux based on image annotations. If the image is annotated as wasm32, crun will bypass Linux container setup and just use WasmEdge to run it. Based on crun, we can get the entire Kubernetes stack CRI-O, containerd, Podman, kind, micro k8s, k8s etc to work with WASM images.
+Option #2 is to use an OCI runtime called crun (the C version of runc, mainly supported by Red Hat). crun decides whether an OCI image is wasm or Linux based on image annotations. If the image is annotated as wasm32, crun will create a container and use an embedded WasmEdge to run it. Based on crun, we can get the entire Kubernetes stack CRI-O, containerd, Podman, kind, micro k8s, k8s etc to work with WASM images.
 
 ## With youki
 
-Option #3 is to use an OCI runtime called youki (the Rust version of runc). Like crun, youki decides whether an OCI image is wasm or Linux based on image annotations. If the image is annotated as wasm32, youki will bypass Linux container setup and just use WasmEdge to run it. Based on youki, we can get the entire Kubernetes stack CRI-O, containerd, Podman, kind, micro k8s, k8s etc to work with WASM images.
+Option #3 is to use an OCI runtime called youki (the Rust version of runc). Like crun, youki decides whether an OCI image is wasm or Linux based on image annotations. If the image is annotated as wasm32, youki will create a container and use an embedded WasmEdge to run it. Based on youki, we can get the entire Kubernetes stack CRI-O, containerd, Podman, kind, micro k8s, k8s etc to work with WASM images.
 
 Both crun and youki could use the following image to show how it works.
 


### PR DESCRIPTION
The previous wording stated crun/youki would bypass Linux Containers if WASM was used. This is not true, to the best of my knowledge.

## Explanation

`crun` nor `youki` skip container creation when running WASM. They use an embedded WASM runtime but still create a container for it. To me the wording sounds like no container would be created so I changed it to explicitly mention the creation of a container.
I also removed the bold formatting at the beginning of the containerd paragraph so they match.

## Related issue

## What type of PR is this

/kind documentation

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 
-->
Clarifies that a container is still created when WASM is executed with `crun` or `youki` and explains that both runtimes execute WASM with an embedded WasmEdge.
I think this clarification is important because someone wanting to run a Linux Container and a WASM module side by side in the same Pod might be confused how this is achieved if WASM would not run inside a container.