### PR TITLE
docs: fix typos and spacing in contributing guides

### DIFF
--- a/docs/contribute/installer.md
+++ b/docs/contribute/installer.md
@@ -64,7 +64,7 @@ The actual installer handles all stuff. It supports python2.7 (not tested on ear
 - Full Option: `--version VERSION`
 - Description: Install the given VERSION of WasmEdge
 - Available Value: VERSION `{{ wasmedge_version }}` or other valid release versions.
-- Note - If supplied an invalid or nonexistent version, the installer exists with an error.
+- Note - If supplied an invalid or nonexistent version, the installer exits with an error.
 
 ### Installation path
 

--- a/docs/contribute/installer_v2.md
+++ b/docs/contribute/installer_v2.md
@@ -6,11 +6,11 @@ sidebar_position: 7
 
 ## Overview
 
-WasmEdge installer V2 is designed for installing the Core Tools (`wasmedge`, `wasmedge compile`), the Libraries (`libwasmedge`),  and the WASI-NN GGML/GGUF Plugin..
+WasmEdge installer V2 is designed for installing the Core Tools (`wasmedge`, `wasmedge compile`), the Libraries (`libwasmedge`), and the WASI-NN GGML/GGUF Plugin.
 
 ## Dependencies
 
-This is a pure shell script implementation. The only dependecies are `curl` or `wget` for downloading the tarballs, and `tar` for extracting them.
+This is a pure shell script implementation. The only dependencies are `curl` or `wget` for downloading the tarballs, and `tar` for extracting them.
 
 
 ## Usage
@@ -95,7 +95,7 @@ The installer entry point.
 
 - WasmEdge installation appends all the files it installs to a file which is located in the installer directory named `env` with its path as `$INSTALLATION_PATH/env`.
 
-### Shell and it's configuration
+### Shell and its configuration
 
 - Source string in shell configuration is given as `. $INSTALLATION_PATH/env` so that it exports the necessary environment variables for WasmEdge.
 - Shell configuration file is appended with source string if it cannot find the source string in that file.

--- a/docs/contribute/overview.md
+++ b/docs/contribute/overview.md
@@ -5,7 +5,7 @@ displayed_sidebar: contributeSidebar
 
 # Contribute and Extend WasmEdge
 
-Contribution is always welcome! The WebAssembly ecosystem is still in its early days. Hosted by CNCF, WasmEdge aims to become an open source “reference implementation” of WebAssembly and its edge-related extensions. WasmEdge is developed in the open, and is constantly being improved by our users, contributors, and maintainers. It is because of you that we can bring great software to the community.We are looking forward to working together with you!
+Contribution is always welcome! The WebAssembly ecosystem is still in its early days. Hosted by CNCF, WasmEdge aims to become an open source “reference implementation” of WebAssembly and its edge-related extensions. WasmEdge is developed in the open, and is constantly being improved by our users, contributors, and maintainers. It is because of you that we can bring great software to the community. We are looking forward to working together with you!
 
 To help new contributors understand WasmEdge development workflow, this guide will include
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/contribute/overview.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/contribute/overview.md
@@ -5,7 +5,7 @@ displayed_sidebar: contributeSidebar
 
 # Contribute and Extend WasmEdge
 
-Contribution is always welcome! The WebAssembly ecosystem is still in its early days. Hosted by CNCF, WasmEdge aims to become an open source “reference implementation” of WebAssembly and its edge-related extensions. WasmEdge is developed in the open, and is constantly being improved by our users, contributors, and maintainers. It is because of you that we can bring great software to the community.We are looking forward to working together with you!
+Contribution is always welcome! The WebAssembly ecosystem is still in its early days. Hosted by CNCF, WasmEdge aims to become an open source “reference implementation” of WebAssembly and its edge-related extensions. WasmEdge is developed in the open, and is constantly being improved by our users, contributors, and maintainers. It is because of you that we can bring great software to the community. We are looking forward to working together with you!
 
 To help new contributors understand WasmEdge development workflow, this guide will include
 


### PR DESCRIPTION
## Explanation

Hi team,

I found several typos and spacing issues while reading the contributing guides, here is the fix PR. Thanks!

## Related issue

N/A

## What type of PR is this

/kind documentation

## Proposed Changes

Fix typos and spacing in contributing guides
