### PR TITLE
docs: add documentation for parse, validate, and instantiate subcommands

### DIFF
--- a/docs/start/build-and-run/cli.md
+++ b/docs/start/build-and-run/cli.md
@@ -18,6 +18,16 @@ By default, the `wasmedge` will execute WebAssembly programs in interpreter mode
 The original `wasmedgec` tool is changed to `wasmedge compile`. The [`wasmedge compile` CLI tool](aot.md) is the ahead-of-time compiler to compile the WebAssembly file into native code.
 :::
 
+The `wasmedge` CLI supports the following subcommands:
+
+| Subcommand | Description |
+| --- | --- |
+| [`run`](run.md) | Execute a WebAssembly program. |
+| [`compile`](aot.md) | Ahead-of-time compile a WebAssembly file into native code. |
+| [`parse`](parse.md) | Parse a WebAssembly module and display its section details. |
+| [`validate`](validate.md) | Validate a WebAssembly module against the specification. |
+| [`instantiate`](instantiate.md) | Instantiate a WebAssembly module, checking that all imports can be resolved. |
+
 ```bash
 $ wasmedge -v
 wasmedge version {{ wasmedge_version }}
@@ -28,7 +38,14 @@ Users can run the `wasmedge -h` to realize the command line options quickly or [
 ```bash
 $ wasmedge -h
 USAGE
-   wasmedge [OPTIONS] [--] WASM_OR_SO [ARG ...]
+   wasmedge [SUBCOMMANDS] [OPTIONS] [--] WASM_OR_SO [ARG ...]
+
+SUBCOMMANDS
+   compile        Wasmedge compiler subcommand
+   run            Wasmedge runtime tool subcommand
+   parse          Wasmedge parse tool subcommand
+   instantiate    Wasmedge instantiate tool subcommand
+   validate       Wasmedge validate tool subcommand
 
 ...
 ```

--- a/docs/start/build-and-run/instantiate.md
+++ b/docs/start/build-and-run/instantiate.md
@@ -4,7 +4,7 @@ sidebar_position: 7
 
 # `wasmedge instantiate` CLI
 
-After [installation](../install.md#install), users can execute the `wasmedge instantiate` command.
+After [installation](https://wasmedge.org/docs/start/install#install), users can execute the `wasmedge instantiate` command.
 
 The `wasmedge instantiate` command loads, validates, and instantiates a WebAssembly module. It checks that all imports can be resolved and that the module can be fully instantiated, but does **not** execute any functions. This is useful for verifying that a WASM module can be successfully linked and instantiated in a given environment before running it.
 

--- a/docs/start/build-and-run/instantiate.md
+++ b/docs/start/build-and-run/instantiate.md
@@ -1,0 +1,133 @@
+---
+sidebar_position: 7
+---
+
+# `wasmedge instantiate` CLI
+
+After [installation](../install.md#install), users can execute the `wasmedge instantiate` command.
+
+The `wasmedge instantiate` command loads, validates, and instantiates a WebAssembly module. It checks that all imports can be resolved and that the module can be fully instantiated, but does **not** execute any functions. This is useful for verifying that a WASM module can be successfully linked and instantiated in a given environment before running it.
+
+The `wasmedge instantiate` command also supports linking additional WASM modules, allowing you to verify that multi-module dependencies resolve correctly.
+
+```bash
+$ wasmedge instantiate -h
+USAGE
+   wasmedge instantiate [OPTIONS] [--] WASM_OR_SO
+
+...
+```
+
+## Options
+
+The options of the `wasmedge instantiate` command are as follows.
+
+1. `-h|--help`: Show the help messages. Will ignore the other arguments below.
+2. _(Optional)_ `--log-level`: Set logging level. Valid values: `off`, `trace`, `debug`, `info`, `warning`, `error`, `fatal`. Default is `info`.
+3. _(Optional)_ `--forbidden-plugin`: List of plugins to ignore.
+4. _(Optional)_ `--module`: Register additional WASM modules for linking. Each module can be specified as `--module name:path`, where `name` is the module name to export and `path` is the WASM file path. This option can be repeated to register multiple modules.
+5. _(Optional)_ `--dir`: Bind directories into WASI virtual filesystem.
+   - Use `--dir guest_path:host_path` to bind the host path into the guest path in WASI virtual system.
+6. _(Optional)_ `--env`: Assign the environment variables in WASI.
+   - Use `--env ENV_NAME=VALUE` to assign the environment variable.
+7. _(Optional)_ `--memory-page-limit`: Set the limitation of pages (as size of 64 KiB) in every memory instance.
+8. _(Optional)_ WebAssembly proposals:
+   - Use `--wasm-1` to set the environment as WASM 1.0 standard. This standard includes the following proposals:
+      - [Import/Export of Mutable Globals](https://github.com/WebAssembly/mutable-global)
+   - Use `--wasm-2` to set the environment as WASM 2.0 standard. This standard includes the WASM 1.0 and following proposals:
+      - [Non-Trapping Float-to-Int Conversions](https://github.com/WebAssembly/nontrapping-float-to-int-conversions)
+      - [Sign-Extension Operators](https://github.com/WebAssembly/sign-extension-ops)
+      - [Multi-value](https://github.com/WebAssembly/multi-value)
+      - [Bulk Memory Operations](https://github.com/WebAssembly/bulk-memory-operations)
+      - [Reference Types](https://github.com/WebAssembly/reference-types)
+      - [Fixed-width SIMD](https://github.com/webassembly/simd)
+   - Use `--wasm-3` to set the environment as WASM 3.0 standard (Currently default since 0.16.0). This standard includes the WASM 2.0 and following proposals:
+      - [Tail call](https://github.com/WebAssembly/tail-call)
+      - [Extended Constant Expressions](https://github.com/WebAssembly/extended-const)
+      - [Typed-Function References](https://github.com/WebAssembly/function-references)
+      - [Garbage Collection](https://github.com/WebAssembly/gc)
+      - [Multiple Memories](https://github.com/WebAssembly/multi-memory)
+      - [Relaxed SIMD](https://github.com/webassembly/relaxed-simd)
+      - [Exception Handling](https://github.com/WebAssembly/exception-handling)
+      - [Memory64 (currently not implemented)](https://github.com/WebAssembly/memory64)
+   - Use `--disable-import-export-mut-globals` to disable the [Import/Export of Mutable Globals](https://github.com/WebAssembly/mutable-global) proposal (Default `ON`).
+   - Use `--disable-non-trap-float-to-int` to disable the [Non-Trapping Float-to-Int Conversions](https://github.com/WebAssembly/nontrapping-float-to-int-conversions) proposal (Default `ON`).
+   - Use `--disable-sign-extension-operators` to disable the [Sign-Extension Operators](https://github.com/WebAssembly/sign-extension-ops) proposal (Default `ON`).
+   - Use `--disable-multi-value` to disable the [Multi-value](https://github.com/WebAssembly/multi-value) proposal (Default `ON`).
+   - Use `--disable-bulk-memory` to disable the [Bulk Memory Operations](https://github.com/WebAssembly/bulk-memory-operations) proposal (Default `ON`).
+   - Use `--disable-reference-types` to disable the [Reference Types](https://github.com/WebAssembly/reference-types) proposal (Default `ON`).
+   - Use `--disable-simd` to disable the [Fixed-width SIMD](https://github.com/webassembly/simd) proposal (Default `ON`).
+   - Use `--disable-tail-call` to disable the [Tail call](https://github.com/WebAssembly/tail-call) proposal (Default `ON`).
+   - Use `--disable-extended-const` to disable the [Extended Constant Expressions](https://github.com/WebAssembly/extended-const) proposal (Default `ON`).
+   - Use `--disable-function-reference` to disable the [Typed-Function References](https://github.com/WebAssembly/function-references) proposal (Default `ON`).
+   - Use `--disable-gc` to disable the [Garbage Collection](https://github.com/WebAssembly/gc) proposal (Default `ON`).
+   - Use `--disable-multi-memory` to disable the [Multiple Memories](https://github.com/WebAssembly/multi-memory) proposal (Default `ON`).
+   - Use `--disable-relaxed-simd` to disable the [Relaxed SIMD](https://github.com/webassembly/relaxed-simd) proposal (Default `ON`).
+   - Use `--disable-exception-handling` to disable the [Exception Handling](https://github.com/WebAssembly/exception-handling) proposal (Default `ON`).
+   - Use `--enable-threads` to enable the [Threads](https://github.com/webassembly/threads) proposal (Default `OFF`).
+   - Use `--enable-component` to enable the [Component Model](https://github.com/WebAssembly/component-model) proposal (Default `OFF`, loader phase only).
+   - Use `--enable-all` to enable ALL proposals above.
+9. Input WASM file (`/path/to/wasm/file`).
+
+## Example
+
+### Instantiating a self-contained module
+
+We created the hand-written [fibonacci.wat](https://github.com/WasmEdge/WasmEdge/raw/master/examples/wasm/fibonacci.wat) and used the [wat2wasm](https://webassembly.github.io/wabt/demo/wat2wasm/) tool to convert it into the `fibonacci.wasm` WebAssembly program. It exported a `fib()` function which takes a single `i32` integer as the input parameter.
+
+You can run:
+
+```bash
+wasmedge instantiate fibonacci.wasm
+```
+
+The output will be:
+
+```bash
+[2026-03-24 02:07:47.135] [info] Instantiation succeeded.
+```
+
+The exit code will be `0`.
+
+### Instantiation failure due to unresolved imports
+
+We created the hand-written [bad_instantiate.wat](https://github.com/WasmEdge/WasmEdge/raw/master/examples/wasm/bad_instantiate.wat) and used the [wat2wasm](https://webassembly.github.io/wabt/demo/wat2wasm/) tool to convert it into the `bad_instantiate.wasm` WebAssembly program. This module imports functions, memory, tables, and globals from an `env` module that is not available in the CLI environment, causing instantiation to fail.
+
+You can run:
+
+```bash
+wasmedge instantiate bad_instantiate.wasm
+```
+
+The output will be:
+
+```bash
+[2026-04-09 00:33:46.404] [error] instantiation failed: unknown import, Code: 0x302
+[2026-04-09 00:33:46.404] [error]     When linking module: "env" , memory name: "memory"
+[2026-04-09 00:33:46.404] [error]     At AST node: import description
+[2026-04-09 00:33:46.404] [error]     This may be the import of host environment like JavaScript or Golang. Please check that you've registered the necessary host modules from the host programming language.
+[2026-04-09 00:33:46.404] [error]     At AST node: import section
+[2026-04-09 00:33:46.404] [error]     At AST node: module
+```
+
+The exit code will be `1`.
+
+### Multi-module linking
+
+You can register additional WASM modules to satisfy imports using the `--module` option. For example, if `main.wasm` imports from a module named `utils`, you can provide it:
+
+```bash
+wasmedge instantiate --module utils:utils.wasm main.wasm
+```
+
+Multiple modules can be linked by repeating the `--module` flag:
+
+```bash
+wasmedge instantiate --module utils:utils.wasm --module math:math.wasm main.wasm
+```
+
+If all imports are resolved successfully, the output will be:
+
+```bash
+[info] Instantiation succeeded.
+```

--- a/docs/start/build-and-run/parse.md
+++ b/docs/start/build-and-run/parse.md
@@ -4,7 +4,7 @@ sidebar_position: 5
 
 # `wasmedge parse` CLI
 
-After [installation](../install.md#install), users can execute the `wasmedge parse` command.
+After [installation](https://wasmedge.org/docs/start/install#install), users can execute the `wasmedge parse` command.
 
 The `wasmedge parse` command loads a WebAssembly module and displays a detailed summary of its structure, including all sections defined in the binary (types, imports, functions, globals, exports, code, memory, tables, and custom sections). It is useful for inspecting WASM modules without executing them.
 

--- a/docs/start/build-and-run/parse.md
+++ b/docs/start/build-and-run/parse.md
@@ -1,0 +1,158 @@
+---
+sidebar_position: 5
+---
+
+# `wasmedge parse` CLI
+
+After [installation](../install.md#install), users can execute the `wasmedge parse` command.
+
+The `wasmedge parse` command loads a WebAssembly module and displays a detailed summary of its structure, including all sections defined in the binary (types, imports, functions, globals, exports, code, memory, tables, and custom sections). It is useful for inspecting WASM modules without executing them.
+
+```bash
+$ wasmedge parse -h
+USAGE
+   wasmedge parse [OPTIONS] [--] WASM_OR_SO
+
+...
+```
+
+## Options
+
+The options of the `wasmedge parse` command are as follows.
+
+1. `-h|--help`: Show the help messages. Will ignore the other arguments below.
+2. _(Optional)_ `--log-level`: Set logging level. Valid values: `off`, `trace`, `debug`, `info`, `warning`, `error`, `fatal`. Default is `info`.
+3. _(Optional)_ `--forbidden-plugin`: List of plugins to ignore.
+4. _(Optional)_ WebAssembly proposals:
+   - Use `--wasm-1` to set the environment as WASM 1.0 standard. This standard includes the following proposals:
+      - [Import/Export of Mutable Globals](https://github.com/WebAssembly/mutable-global)
+   - Use `--wasm-2` to set the environment as WASM 2.0 standard. This standard includes the WASM 1.0 and following proposals:
+      - [Non-Trapping Float-to-Int Conversions](https://github.com/WebAssembly/nontrapping-float-to-int-conversions)
+      - [Sign-Extension Operators](https://github.com/WebAssembly/sign-extension-ops)
+      - [Multi-value](https://github.com/WebAssembly/multi-value)
+      - [Bulk Memory Operations](https://github.com/WebAssembly/bulk-memory-operations)
+      - [Reference Types](https://github.com/WebAssembly/reference-types)
+      - [Fixed-width SIMD](https://github.com/webassembly/simd)
+   - Use `--wasm-3` to set the environment as WASM 3.0 standard (Currently default since 0.16.0). This standard includes the WASM 2.0 and following proposals:
+      - [Tail call](https://github.com/WebAssembly/tail-call)
+      - [Extended Constant Expressions](https://github.com/WebAssembly/extended-const)
+      - [Typed-Function References](https://github.com/WebAssembly/function-references)
+      - [Garbage Collection](https://github.com/WebAssembly/gc)
+      - [Multiple Memories](https://github.com/WebAssembly/multi-memory)
+      - [Relaxed SIMD](https://github.com/webassembly/relaxed-simd)
+      - [Exception Handling](https://github.com/WebAssembly/exception-handling)
+      - [Memory64 (currently not implemented)](https://github.com/WebAssembly/memory64)
+   - Use `--disable-import-export-mut-globals` to disable the [Import/Export of Mutable Globals](https://github.com/WebAssembly/mutable-global) proposal (Default `ON`).
+   - Use `--disable-non-trap-float-to-int` to disable the [Non-Trapping Float-to-Int Conversions](https://github.com/WebAssembly/nontrapping-float-to-int-conversions) proposal (Default `ON`).
+   - Use `--disable-sign-extension-operators` to disable the [Sign-Extension Operators](https://github.com/WebAssembly/sign-extension-ops) proposal (Default `ON`).
+   - Use `--disable-multi-value` to disable the [Multi-value](https://github.com/WebAssembly/multi-value) proposal (Default `ON`).
+   - Use `--disable-bulk-memory` to disable the [Bulk Memory Operations](https://github.com/WebAssembly/bulk-memory-operations) proposal (Default `ON`).
+   - Use `--disable-reference-types` to disable the [Reference Types](https://github.com/WebAssembly/reference-types) proposal (Default `ON`).
+   - Use `--disable-simd` to disable the [Fixed-width SIMD](https://github.com/webassembly/simd) proposal (Default `ON`).
+   - Use `--disable-tail-call` to disable the [Tail call](https://github.com/WebAssembly/tail-call) proposal (Default `ON`).
+   - Use `--disable-extended-const` to disable the [Extended Constant Expressions](https://github.com/WebAssembly/extended-const) proposal (Default `ON`).
+   - Use `--disable-function-reference` to disable the [Typed-Function References](https://github.com/WebAssembly/function-references) proposal (Default `ON`).
+   - Use `--disable-gc` to disable the [Garbage Collection](https://github.com/WebAssembly/gc) proposal (Default `ON`).
+   - Use `--disable-multi-memory` to disable the [Multiple Memories](https://github.com/WebAssembly/multi-memory) proposal (Default `ON`).
+   - Use `--disable-relaxed-simd` to disable the [Relaxed SIMD](https://github.com/webassembly/relaxed-simd) proposal (Default `ON`).
+   - Use `--disable-exception-handling` to disable the [Exception Handling](https://github.com/WebAssembly/exception-handling) proposal (Default `ON`).
+   - Use `--enable-threads` to enable the [Threads](https://github.com/webassembly/threads) proposal (Default `OFF`).
+   - Use `--enable-component` to enable the [Component Model](https://github.com/WebAssembly/component-model) proposal (Default `OFF`, loader phase only).
+   - Use `--enable-all` to enable ALL proposals above.
+5. Input WASM file (`/path/to/wasm/file`).
+
+## Output
+
+The `wasmedge parse` command prints a structured summary of the WASM binary, organized by section:
+
+- **Type** — Function signatures (parameter and return types).
+- **Import** — Imported functions, memories, tables, and globals with their source module and name.
+- **Function** — Locally defined functions with their type signature index.
+- **Global** — Global variables with type, mutability, and initializer expression.
+- **Export** — Exported functions, globals, memories, and tables.
+- **Code** — Code segments with byte sizes for each function.
+- **Custom** — Custom sections such as the `name` section, which maps indices to human-readable names.
+
+If a `name` custom section is present in the WASM binary, function and global names will be displayed alongside their indices throughout the output.
+
+## Example
+
+We created the hand-written [parse_example.wat](https://github.com/WasmEdge/WasmEdge/raw/master/examples/wasm/parse_example.wat) and used the [wat2wasm](https://webassembly.github.io/wabt/demo/wat2wasm/) tool to convert it into the `parse_example.wasm` WebAssembly program. It contains imports, multiple function signatures, globals with initializers, and a `name` custom section.
+
+You can run:
+
+```bash
+wasmedge parse parse_example.wasm
+```
+
+The output will be:
+
+```bash
+parse_example.wasm:  file format wasm 0x1
+
+Section Details:
+
+Type[5]:
+ - type[0] (i32, i32) -> nil
+ - type[1] () -> nil
+ - type[2] (i32, i32) -> i32
+ - type[3] (i64) -> i64
+ - type[4] () -> f64
+Import[4]:
+ - memory[0] pages: initial=2 max=16 <- env.memory
+ - func[0] sig=0 <log> <- env.log
+ - table[0] <- env.table
+ - global[0] i32 mutable=0 <imported_base> <- env.base
+Function[7]:
+ - func[1] sig=1 <__wasm_call_ctors>
+ - func[2] sig=2 <add>
+ - func[3] sig=2 <sub>
+ - func[4] sig=2 <mul>
+ - func[5] sig=3 <factorial>
+ - func[6] sig=4 <get_pi>
+ - func[7] sig=0 <call_log>
+Global[5]:
+ - global[1] i32 mutable=1 <__stack_pointer> - init i32=66560
+ - global[2] i32 mutable=0 <__heap_base> - init i32=131072
+ - global[3] i32 mutable=0 <__data_end> - init i32=1024
+ - global[4] f64 mutable=0 <pi_approx> - init f64=3.14159
+ - global[5] i64 mutable=0 <big_val> - init i64=9999999999
+Export[13]:
+ - func[1] <__wasm_call_ctors> -> "__wasm_call_ctors"
+ - func[2] <add> -> "add"
+ - func[3] <sub> -> "sub"
+ - func[4] <mul> -> "mul"
+ - func[5] <factorial> -> "factorial"
+ - func[6] <get_pi> -> "get_pi"
+ - func[7] <call_log> -> "call_log"
+ - global[1] -> "__stack_pointer"
+ - global[2] -> "__heap_base"
+ - global[3] -> "__data_end"
+ - global[4] -> "pi_approx"
+ - global[5] -> "big_val"
+ - table[1] -> "func_table"
+Code[7]:
+ - func[1] size=2 <__wasm_call_ctors>
+ - func[2] size=7 <add>
+ - func[3] size=7 <sub>
+ - func[4] size=7 <mul>
+ - func[5] size=39 <factorial>
+ - func[6] size=11 <get_pi>
+ - func[7] size=8 <call_log>
+Custom:
+ - name: "name"
+ - func[0] <log>
+ - func[1] <__wasm_call_ctors>
+ - func[2] <add>
+ - func[3] <sub>
+ - func[4] <mul>
+ - func[5] <factorial>
+ - func[6] <get_pi>
+ - func[7] <call_log>
+ - global[0] <imported_base>
+ - global[1] <__stack_pointer>
+ - global[2] <__heap_base>
+ - global[3] <__data_end>
+ - global[4] <pi_approx>
+ - global[5] <big_val>
+```

--- a/docs/start/build-and-run/validate.md
+++ b/docs/start/build-and-run/validate.md
@@ -4,7 +4,7 @@ sidebar_position: 6
 
 # `wasmedge validate` CLI
 
-After [installation](../install.md#install), users can execute the `wasmedge validate` command.
+After [installation](https://wasmedge.org/docs/start/install#install), users can execute the `wasmedge validate` command.
 
 The `wasmedge validate` command loads a WebAssembly module and runs the validation phase, checking that the module conforms to the WebAssembly specification. It does **not** instantiate or execute the module. This is useful for verifying correctness of a WASM binary before deployment or execution.
 

--- a/docs/start/build-and-run/validate.md
+++ b/docs/start/build-and-run/validate.md
@@ -1,0 +1,106 @@
+---
+sidebar_position: 6
+---
+
+# `wasmedge validate` CLI
+
+After [installation](../install.md#install), users can execute the `wasmedge validate` command.
+
+The `wasmedge validate` command loads a WebAssembly module and runs the validation phase, checking that the module conforms to the WebAssembly specification. It does **not** instantiate or execute the module. This is useful for verifying correctness of a WASM binary before deployment or execution.
+
+```bash
+$ wasmedge validate -h
+USAGE
+   wasmedge validate [OPTIONS] [--] WASM_OR_SO
+
+...
+```
+
+## Options
+
+The options of the `wasmedge validate` command are as follows.
+
+1. `-h|--help`: Show the help messages. Will ignore the other arguments below.
+2. _(Optional)_ `--log-level`: Set logging level. Valid values: `off`, `trace`, `debug`, `info`, `warning`, `error`, `fatal`. Default is `info`.
+3. _(Optional)_ `--forbidden-plugin`: List of plugins to ignore.
+4. _(Optional)_ WebAssembly proposals:
+   - Use `--wasm-1` to set the environment as WASM 1.0 standard. This standard includes the following proposals:
+      - [Import/Export of Mutable Globals](https://github.com/WebAssembly/mutable-global)
+   - Use `--wasm-2` to set the environment as WASM 2.0 standard. This standard includes the WASM 1.0 and following proposals:
+      - [Non-Trapping Float-to-Int Conversions](https://github.com/WebAssembly/nontrapping-float-to-int-conversions)
+      - [Sign-Extension Operators](https://github.com/WebAssembly/sign-extension-ops)
+      - [Multi-value](https://github.com/WebAssembly/multi-value)
+      - [Bulk Memory Operations](https://github.com/WebAssembly/bulk-memory-operations)
+      - [Reference Types](https://github.com/WebAssembly/reference-types)
+      - [Fixed-width SIMD](https://github.com/webassembly/simd)
+   - Use `--wasm-3` to set the environment as WASM 3.0 standard (Currently default since 0.16.0). This standard includes the WASM 2.0 and following proposals:
+      - [Tail call](https://github.com/WebAssembly/tail-call)
+      - [Extended Constant Expressions](https://github.com/WebAssembly/extended-const)
+      - [Typed-Function References](https://github.com/WebAssembly/function-references)
+      - [Garbage Collection](https://github.com/WebAssembly/gc)
+      - [Multiple Memories](https://github.com/WebAssembly/multi-memory)
+      - [Relaxed SIMD](https://github.com/webassembly/relaxed-simd)
+      - [Exception Handling](https://github.com/WebAssembly/exception-handling)
+      - [Memory64 (currently not implemented)](https://github.com/WebAssembly/memory64)
+   - Use `--disable-import-export-mut-globals` to disable the [Import/Export of Mutable Globals](https://github.com/WebAssembly/mutable-global) proposal (Default `ON`).
+   - Use `--disable-non-trap-float-to-int` to disable the [Non-Trapping Float-to-Int Conversions](https://github.com/WebAssembly/nontrapping-float-to-int-conversions) proposal (Default `ON`).
+   - Use `--disable-sign-extension-operators` to disable the [Sign-Extension Operators](https://github.com/WebAssembly/sign-extension-ops) proposal (Default `ON`).
+   - Use `--disable-multi-value` to disable the [Multi-value](https://github.com/WebAssembly/multi-value) proposal (Default `ON`).
+   - Use `--disable-bulk-memory` to disable the [Bulk Memory Operations](https://github.com/WebAssembly/bulk-memory-operations) proposal (Default `ON`).
+   - Use `--disable-reference-types` to disable the [Reference Types](https://github.com/WebAssembly/reference-types) proposal (Default `ON`).
+   - Use `--disable-simd` to disable the [Fixed-width SIMD](https://github.com/webassembly/simd) proposal (Default `ON`).
+   - Use `--disable-tail-call` to disable the [Tail call](https://github.com/WebAssembly/tail-call) proposal (Default `ON`).
+   - Use `--disable-extended-const` to disable the [Extended Constant Expressions](https://github.com/WebAssembly/extended-const) proposal (Default `ON`).
+   - Use `--disable-function-reference` to disable the [Typed-Function References](https://github.com/WebAssembly/function-references) proposal (Default `ON`).
+   - Use `--disable-gc` to disable the [Garbage Collection](https://github.com/WebAssembly/gc) proposal (Default `ON`).
+   - Use `--disable-multi-memory` to disable the [Multiple Memories](https://github.com/WebAssembly/multi-memory) proposal (Default `ON`).
+   - Use `--disable-relaxed-simd` to disable the [Relaxed SIMD](https://github.com/webassembly/relaxed-simd) proposal (Default `ON`).
+   - Use `--disable-exception-handling` to disable the [Exception Handling](https://github.com/WebAssembly/exception-handling) proposal (Default `ON`).
+   - Use `--enable-threads` to enable the [Threads](https://github.com/webassembly/threads) proposal (Default `OFF`).
+   - Use `--enable-component` to enable the [Component Model](https://github.com/WebAssembly/component-model) proposal (Default `OFF`, loader phase only).
+   - Use `--enable-all` to enable ALL proposals above.
+5. Input WASM file (`/path/to/wasm/file`).
+
+## Example
+
+### Validating a correct module
+
+We created the hand-written [fibonacci.wat](https://github.com/WasmEdge/WasmEdge/raw/master/examples/wasm/fibonacci.wat) and used the [wat2wasm](https://webassembly.github.io/wabt/demo/wat2wasm/) tool to convert it into the `fibonacci.wasm` WebAssembly program. It exported a `fib()` function which takes a single `i32` integer as the input parameter.
+
+You can run:
+
+```bash
+wasmedge validate fibonacci.wasm
+```
+
+The output will be:
+
+```bash
+[2026-03-24 02:07:35.939] [info] Validation succeeded.
+```
+
+The exit code will be `0`.
+
+### Validating an invalid module
+
+We created the hand-written [bad_validate.wat](https://github.com/WasmEdge/WasmEdge/raw/master/examples/wasm/bad_validate.wat) and used the [wat2wasm](https://webassembly.github.io/wabt/demo/wat2wasm/) tool to convert it into the `bad_validate.wasm` WebAssembly program. This module intentionally contains a type mismatch to demonstrate validation failure.
+
+You can run:
+
+```bash
+wasmedge validate bad_validate.wasm
+```
+
+The output will be:
+
+```bash
+[2026-03-24 02:08:49.475] [error] validation failed: type mismatch, Code: 0x202
+[2026-03-24 02:08:49.475] [error]     Mismatched value type. Expected: i32 , Got: i64
+[2026-03-24 02:08:49.475] [error]     In instruction: end (0x08) , Bytecode offset: 0x00000026
+[2026-03-24 02:08:49.475] [error]     At AST node: expression
+[2026-03-24 02:08:49.475] [error]     At AST node: code segment
+[2026-03-24 02:08:49.475] [error]     At AST node: code section
+[2026-03-24 02:08:49.475] [error]     At AST node: module
+```
+
+The exit code will be `1`.


### PR DESCRIPTION
## Explanation

Adds documentation for the three new CLI subcommands (`parse`, `validate`, `instantiate`) introduced in WasmEdge/WasmEdge#4694. Also updates the main CLI page to list all available subcommands.

## Related issue

Closes WasmEdge/WasmEdge#4688

## What type of PR is this

/kind documentation

## Proposed Changes

- Added [parse.md](cci:7://file:///Users/divyanshi.khatri/github/docs/docs/start/build-and-run/parse.md:0:0-0:0) — documents the `wasmedge parse` subcommand, which displays a WASM module's section details (types, imports, functions, globals, exports, code, custom sections).
- Added [validate.md](cci:7://file:///Users/divyanshi.khatri/github/docs/docs/start/build-and-run/validate.md:0:0-0:0) — documents the `wasmedge validate` subcommand, which checks a WASM module against the spec without executing it.
- Added [instantiate.md](cci:7://file:///Users/divyanshi.khatri/github/docs/docs/start/build-and-run/instantiate.md:0:0-0:0) — documents the `wasmedge instantiate` subcommand, which loads, validates, and instantiates a module (with multi-module linking support via `--module`).
- Updated [cli.md](cci:7://file:///Users/divyanshi.khatri/github/docs/docs/start/build-and-run/cli.md:0:0-0:0) — added a subcommands table linking to all five subcommand pages, and updated the USAGE block to reflect the new CLI structure.

Each new page follows the same structure and conventions as the existing subcommands documentations.