### PR TITLE
fix: restore lint-staged pre-commit hook

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -2,7 +2,6 @@
   "*.{js,jsx,mjs}": ["eslint --fix"],
   "*.css": ["stylelint --allow-empty-input --fix"],
   "*": [
-    "prettier --ignore-unknown --write",
-    "cspell --no-must-find-files --no-progress"
+    "prettier --ignore-unknown --write"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "format:diff": "prettier --check .",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
+    "lint-staged": "lint-staged",
     "lint": "npm run lint:js && npm run lint:style",
     "lint:ci": "npm run lint:js --quiet && npm run lint:style",
     "lint:js": "eslint --cache --report-unused-disable-directives \"**/*.{js,jsx,ts,tsx}\"",


### PR DESCRIPTION
## Explanation

Fixes the Husky pre-commit hook by adding the missing `lint-staged` npm script and removing the `cspell` step from lint-staged config (cspell is not installed/configured in this repo, which caused commits to fail).

## Related issue

Closes #99

## What type of PR is this

/kind bug

## Proposed Changes

- Add `"lint-staged": "lint-staged"` to `package.json` scripts (required by `.husky/pre-commit`).
- Remove `cspell` from `.lintstagedrc.json` so pre-commit does not fail on a missing dependency.