### PR TITLE
docs: update Windows LLVM setup

### DIFF
--- a/docs/contribute/source/os/windows.md
+++ b/docs/contribute/source/os/windows.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # Build on Windows 10
 
-You can also find the details [here](https://github.com/WasmEdge/WasmEdge/blob/master/.github/workflows/reusable-build-on-windows.yml#L37-L48).
+You can also find the details [here](https://github.com/WasmEdge/WasmEdge/blob/master/.github/workflows/reusable-build-on-windows.yml).
 
 ## Get Source Code
 
@@ -15,16 +15,11 @@ cd WasmEdge
 
 ## Requirements and Dependencies
 
-WasmEdge requires LLVM 16 and you may need to install these following dependencies by yourself.
+WasmEdge requires LLVM and you may need to install these following dependencies by yourself.
 
 - [Chocolatey](https://chocolatey.org/install), we use it to install `cmake`, `ninja`, and `vswhere`.
-- [Windows SDK 19041](https://blogs.windows.com/windowsdeveloper/2020/05/12/start-developing-on-windows-10-version-2004-today/)
-- LLVM 16.0.6, download the pre-built files [here](https://github.com/WasmEdge/llvm-windows/releases) or you can just follow the `instructions/commands` to download automatically.
-
-<!-- prettier-ignore -->
-:::note
-If you use the community version of Visual Studio, you may encounter errors like: `ninja: error: 'C:/Program Files/Microsoft Visual Studio/2022/Enterprise/DIA SDK/lib/amd64/diaguids.lib', needed by 'test/aot/wasmedgeAOTCoreTests.exe', missing and no known rule to make it`. You need to manually open the file `LLVM-16.0.6-win64/lib/cmake/llvm/LLVMExports.cmake`, search for the only occurrence of `Enterprise` and change it to `Community`. See [this issue](https://github.com/WasmEdge/WasmEdge/issues/1290#issuecomment-1056784554) for details.
-:::
+- [Windows SDK 26100](https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/)
+- LLVM 21.1.3, download the pre-built files [here](https://github.com/WasmEdge/llvm-windows/releases/tag/llvmorg-21.1.3) or you can just follow the `instructions/commands` to download automatically.
 
 ```powershell
 # Install the required tools
@@ -35,15 +30,15 @@ $vsPath = (vswhere -latest -property installationPath)
 # $vsPath = (&"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath)
 
 Import-Module (Join-Path $vsPath "Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
-Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64 -winsdk=10.0.19041.0"
+Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64 -winsdk=10.0.26100.0"
 
-# Download our pre-built LLVM 16 binary
-$llvm = "LLVM-16.0.6-win64-MultiThreadedDLL.zip"
-Invoke-WebRequest -Uri https://github.com/WasmEdge/llvm-windows/releases/download/llvmorg-16.0.6/LLVM-16.0.6-win64-MultiThreadedDLL.zip -OutFile $llvm
+# Download our pre-built LLVM 21 binary
+$llvm = "LLVM-21.1.3-win64-MultiThreadedDLL.zip"
+Invoke-WebRequest -Uri https://github.com/WasmEdge/llvm-windows/releases/download/llvmorg-21.1.3/LLVM-21.1.3-win64-MultiThreadedDLL.zip -OutFile $llvm
 Expand-Archive -Path $llvm
 
 # Set LLVM environment
-$llvm_dir = "$pwd\LLVM-16.0.6-win64-MultiThreadedDLL\LLVM-16.0.6-win64\lib\cmake\llvm"
+$llvm_dir = "$pwd\LLVM-21.1.3-win64-MultiThreadedDLL\LLVM-21.1.3-win64\lib\cmake\llvm"
 ```
 
 ## Build WasmEdge
@@ -53,19 +48,19 @@ On Windows, either Clang-cl or MSVC can be used to build WasmEdge. To use MSVC, 
 ```powershell
 $vsPath = (vswhere -latest -property installationPath)
 Import-Module (Join-Path $vsPath "Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
-Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64 -winsdk=10.0.19041.0"
+Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64 -winsdk=10.0.26100.0"
 # If you would like to use MSVC, and want to use a specific version of MSVC, set the arg `vcvars_ver` like the following.
-# Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64 -winsdk=10.0.19041.0 -vcvars_ver=14.34.31933"
+# Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64 -winsdk=10.0.26100.0 -vcvars_ver=14.34.31933"
 
 # Set LLVM path according to the download location
-$llvm_dir = "$pwd\LLVM-16.0.6-win64-MultiThreadedDLL\LLVM-16.0.6-win64\lib\cmake\llvm"
+$llvm_dir = "$pwd\LLVM-21.1.3-win64-MultiThreadedDLL\LLVM-21.1.3-win64\lib\cmake\llvm"
 
 # Use clang-cl as the compiler.
 # Comment out the following two lines to use MSVC.
 $Env:CC = "clang-cl"
 $Env:CXX = "clang-cl"
 
-cmake -Bbuild -GNinja -DCMAKE_SYSTEM_VERSION=10.0.19041.0 -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL "-DLLVM_DIR=$llvm_dir" -DWASMEDGE_BUILD_TESTS=ON -DWASMEDGE_BUILD_PACKAGE="ZIP" .
+cmake -Bbuild -GNinja -DCMAKE_SYSTEM_VERSION=10.0.26100.0 -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL "-DLLVM_DIR=$llvm_dir" -DWASMEDGE_BUILD_TESTS=ON -DWASMEDGE_BUILD_PACKAGE="ZIP" .
 cmake --build build
 ```
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/contribute/source/os/windows.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/contribute/source/os/windows.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # Build on Windows 10
 
-You can also find the details [here](https://github.com/WasmEdge/WasmEdge/blob/master/.github/workflows/reusable-build-on-windows.yml#L37-L48).
+You can also find the details [here](https://github.com/WasmEdge/WasmEdge/blob/master/.github/workflows/reusable-build-on-windows.yml).
 
 ## Get Source Code
 
@@ -15,16 +15,11 @@ cd WasmEdge
 
 ## Requirements and Dependencies
 
-WasmEdge requires LLVM 16 and you may need to install these following dependencies by yourself.
+WasmEdge requires LLVM and you may need to install these following dependencies by yourself.
 
 - [Chocolatey](https://chocolatey.org/install), we use it to install `cmake`, `ninja`, and `vswhere`.
-- [Windows SDK 19041](https://blogs.windows.com/windowsdeveloper/2020/05/12/start-developing-on-windows-10-version-2004-today/)
-- LLVM 16.0.6, download the pre-built files [here](https://github.com/WasmEdge/llvm-windows/releases) or you can just follow the `instructions/commands` to download automatically.
-
-<!-- prettier-ignore -->
-:::note
-If you use the community version of Visual Studio, you may encounter errors like: `ninja: error: 'C:/Program Files/Microsoft Visual Studio/2022/Enterprise/DIA SDK/lib/amd64/diaguids.lib', needed by 'test/aot/wasmedgeAOTCoreTests.exe', missing and no known rule to make it`. You need to manually open the file `LLVM-16.0.6-win64/lib/cmake/llvm/LLVMExports.cmake`, search for the only occurrence of `Enterprise` and change it to `Community`. See [this issue](https://github.com/WasmEdge/WasmEdge/issues/1290#issuecomment-1056784554) for details.
-:::
+- [Windows SDK 26100](https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/)
+- LLVM 21.1.3, download the pre-built files [here](https://github.com/WasmEdge/llvm-windows/releases/tag/llvmorg-21.1.3) or you can just follow the `instructions/commands` to download automatically.
 
 ```powershell
 # Install the required tools
@@ -35,15 +30,15 @@ $vsPath = (vswhere -latest -property installationPath)
 # $vsPath = (&"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath)
 
 Import-Module (Join-Path $vsPath "Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
-Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64 -winsdk=10.0.19041.0"
+Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64 -winsdk=10.0.26100.0"
 
-# Download our pre-built LLVM 16 binary
-$llvm = "LLVM-16.0.6-win64-MultiThreadedDLL.zip"
-curl -sLO https://github.com/WasmEdge/llvm-windows/releases/download/llvmorg-16.0.6/LLVM-16.0.6-win64-MultiThreadedDLL.zip -o $llvm
+# Download our pre-built LLVM 21 binary
+$llvm = "LLVM-21.1.3-win64-MultiThreadedDLL.zip"
+Invoke-WebRequest -Uri https://github.com/WasmEdge/llvm-windows/releases/download/llvmorg-21.1.3/LLVM-21.1.3-win64-MultiThreadedDLL.zip -OutFile $llvm
 Expand-Archive -Path $llvm
 
 # Set LLVM environment
-$llvm_dir = "$pwd\LLVM-16.0.6-win64-MultiThreadedDLL\LLVM-16.0.6-win64\lib\cmake\llvm"
+$llvm_dir = "$pwd\LLVM-21.1.3-win64-MultiThreadedDLL\LLVM-21.1.3-win64\lib\cmake\llvm"
 ```
 
 ## Build WasmEdge
@@ -53,19 +48,19 @@ On Windows, either Clang-cl or MSVC can be used to build WasmEdge. To use MSVC, 
 ```powershell
 $vsPath = (vswhere -latest -property installationPath)
 Import-Module (Join-Path $vsPath "Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
-Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64 -winsdk=10.0.19041.0"
+Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64 -winsdk=10.0.26100.0"
 # If you would like to use MSVC, and want to use a specific version of MSVC, set the arg `vcvars_ver` like the following.
-# Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64 -winsdk=10.0.19041.0 -vcvars_ver=14.34.31933"
+# Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64 -winsdk=10.0.26100.0 -vcvars_ver=14.34.31933"
 
 # Set LLVM path according to the download location
-$llvm_dir = "$pwd\LLVM-16.0.6-win64-MultiThreadedDLL\LLVM-16.0.6-win64\lib\cmake\llvm"
+$llvm_dir = "$pwd\LLVM-21.1.3-win64-MultiThreadedDLL\LLVM-21.1.3-win64\lib\cmake\llvm"
 
 # Use clang-cl as the compiler.
 # Comment out the following two lines to use MSVC.
 $Env:CC = "clang-cl"
 $Env:CXX = "clang-cl"
 
-cmake -Bbuild -GNinja -DCMAKE_SYSTEM_VERSION=10.0.19041.0 -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL "-DLLVM_DIR=$llvm_dir" -DWASMEDGE_BUILD_TESTS=ON -DWASMEDGE_BUILD_PACKAGE="ZIP" .
+cmake -Bbuild -GNinja -DCMAKE_SYSTEM_VERSION=10.0.26100.0 -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL "-DLLVM_DIR=$llvm_dir" -DWASMEDGE_BUILD_TESTS=ON -DWASMEDGE_BUILD_PACKAGE="ZIP" .
 cmake --build build
 ```
 


### PR DESCRIPTION
## Explanation

This PR updates the Windows source-build instructions to match the current WasmEdge Windows CI setup. The previous page still pointed users at the older LLVM 16.0.6 Windows package and documented a manual Visual Studio Enterprise-to-Community path edit for `diaguids.lib` in `LLVMExports.cmake`.

The current CI uses the WasmEdge `llvm-windows` 21.1.3 package. I also verified the downloaded 21.1.3 asset locally and confirmed its exported CMake metadata no longer contains a hard-coded Visual Studio Enterprise/Community DIA SDK path.

## Related issue

Fixes WasmEdge/WasmEdge#2423.

## What type of PR is this

/kind documentation

## Proposed Changes

- Update the Windows build instructions to LLVM 21.1.3 and Windows SDK 26100.
- Remove the obsolete manual `LLVMExports.cmake` workaround.
- Use `Invoke-WebRequest` in the localized PowerShell download example.

This contribution was developed with assistance from OpenAI Codex.

## Validation

- `git diff --check`
- `npx prettier --check docs/contribute/source/os/windows.md i18n/zh/docusaurus-plugin-content-docs/current/contribute/source/os/windows.md`
- `npm run build`
