### PR TITLE
docs: fix outdated KinD quickstart example

### DIFF
--- a/docs/develop/deploy/kubernetes/kind.md
+++ b/docs/develop/deploy/kubernetes/kind.md
@@ -21,7 +21,7 @@ If KinD is installed, we can directly start with the example from [here](https:/
 # Create a "WASM in KinD" Cluster
 kind create cluster --image ghcr.io/liquid-reply/kind-crun-wasm:v1.23.0
 # Run the example
-kubectl run -it --rm --restart=Never wasi-demo --image=wasmedge/example-wasi:latest --annotations="module.wasm.image/variant=compat-smart" /wasi_example_main.wasm 50000000
+kubectl run -it --rm --restart=Never wasi-demo --image=hydai/wasm-wasi-example:with-wasm-annotation --annotations="module.wasm.image/variant=compat" /wasi_example_main.wasm 50000000
 ```
 
 In the rest of this section, we will explain how to create a KinD node image with wasmedge support.
@@ -88,5 +88,5 @@ Finally, we can build a new `node-wasmedge` image. We create a kind cluster from
 docker build -t node-wasmedge .
 kind create cluster --image node-wasmedge
 # Now you can run the example to validate your cluster
-kubectl run -it --rm --restart=Never wasi-demo --image=wasmedge/example-wasi:latest --annotations="module.wasm.image/variant=compat-smart" /wasi_example_main.wasm 50000000
+kubectl run -it --rm --restart=Never wasi-demo --image=hydai/wasm-wasi-example:with-wasm-annotation --annotations="module.wasm.image/variant=compat" /wasi_example_main.wasm 50000000
 ```


### PR DESCRIPTION

This PR updates the KinD quickstart documentation to use a working example configuration.

Background

Issue #1844 reported that the documented example fails with an Exec format error when following the KinD quickstart guide.

Changes
Replace wasmedge/example-wasi:latest
with hydai/wasm-wasi-example:with-wasm-annotation
Replace module.wasm.image/variant=compat-smart
with module.wasm.image/variant=compat
Update both occurrences in docs/develop/deploy/kubernetes/kind.md
Verification

The updated commands match the working configuration described in Issue #1844 and the upstream kind-crun-wasm example.

Type of Change

Documentation update

Related Issue

Fixes WasmEdge/WasmEdge#1844