### PR TITLE
docs : fix broken GitHub links for WASI proposals and nightly builds

### DIFF
--- a/docs/contribute/source/build_from_src.md
+++ b/docs/contribute/source/build_from_src.md
@@ -19,7 +19,7 @@ Please follow this guide to build and test WasmEdge from the source code.
 
 <!-- prettier-ignore -->
 :::note
-If you just want the latest builds from the `HEAD` of the `master` branch, and do not want to build it yourself, you can download the release package directly from our Github Action's CI artifact. [Here is an example](https://github.com/WasmEdge/WasmEdge/actions/runs/1521549504#artifacts).
+If you just want the latest builds from the `HEAD` of the `master` branch, and do not want to build it yourself, you can download the release package directly from our Github Action's CI artifact. [Here is an example](https://github.com/WasmEdge/WasmEdge/actions/workflows/release.yml).
 :::
 
 ## What Will Be Built

--- a/docs/start/install.md
+++ b/docs/start/install.md
@@ -46,7 +46,7 @@ VERSION={{ wasmedge_version }}
 curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- -v $VERSION
 ```
 
-Suppose you are interested in the latest builds from the `HEAD` of the `master` branch, which is basically WasmEdge's nightly builds. In that case, you can download the release package directly from our Github Action's CI artifact. [Here is an example](https://github.com/WasmEdge/WasmEdge/actions/runs/2969775464#artifacts).
+Suppose you are interested in the latest builds from the `HEAD` of the `master` branch, which is basically WasmEdge's nightly builds. In that case, you can download the release package directly from our Github Action's CI artifact. [Here is an example](https://github.com/WasmEdge/WasmEdge/actions/workflows/release.yml).
 
 #### Install via Nix
 

--- a/docs/start/wasmedge/extensions/proposals.md
+++ b/docs/start/wasmedge/extensions/proposals.md
@@ -54,7 +54,7 @@ The following proposals are under development and may be supported in the future
 
 ## WASI proposals
 
-WasmEdge implements the following [WASI proposals](https://github.com/WebAssembly/WASI/blob/main/Proposals.md):
+WasmEdge implements the following [WASI proposals](https://github.com/WebAssembly/WASI/blob/main/docs/Proposals.md):
 
 | Proposal | Platform: `Linux x86_64` | Platform: `Linux aarch64` | Platform: `x86_64 MacOS` | Platform: `MacOS arm64` |
 | --- | --- | --- | --- | --- |

--- a/i18n/zh/docusaurus-plugin-content-docs/current/contribute/source/build_from_src.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/contribute/source/build_from_src.md
@@ -19,7 +19,7 @@ Please follow this guide to build and test WasmEdge from the source code.
 
 <!-- prettier-ignore -->
 :::note
-If you just want the latest builds from the `HEAD` of the `master` branch, and do not want to build it yourself, you can download the release package directly from our Github Action's CI artifact. [Here is an example](https://github.com/WasmEdge/WasmEdge/actions/runs/1521549504#artifacts).
+If you just want the latest builds from the `HEAD` of the `master` branch, and do not want to build it yourself, you can download the release package directly from our Github Action's CI artifact. [Here is an example](https://github.com/WasmEdge/WasmEdge/actions/workflows/release.yml).
 :::
 
 ## What Will Be Built

--- a/i18n/zh/docusaurus-plugin-content-docs/current/start/install.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/start/install.md
@@ -46,7 +46,7 @@ VERSION={{ wasmedge_version }}
 curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- -v $VERSION
 ```
 
-如果你对 `master` 分支的 `HEAD` 构建感兴趣（这基本上是 WasmEdge 的每夜构建版本）。在这种情况下，可以直接从我们的 Github Action 的 CI artifact 下载发布包。[以下是一个示例链接](https://github.com/WasmEdge/WasmEdge/actions/runs/2969775464#artifacts)。
+如果你对 `master` 分支的 `HEAD` 构建感兴趣（这基本上是 WasmEdge 的每夜构建版本）。在这种情况下，可以直接从我们的 Github Action 的 CI artifact 下载发布包。[以下是一个示例链接](https://github.com/WasmEdge/WasmEdge/actions/workflows/release.yml)。
 
 #### 带插件安装 WasmEdge
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/start/wasmedge/extensions/proposals.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/start/wasmedge/extensions/proposals.md
@@ -47,7 +47,7 @@ WasmEdge 支持以下 [WebAssembly 提案](https://github.com/WebAssembly/propos
 
 ## WASI 提案
 
-WasmEdge 实现了以下 [WASI 提案](https://github.com/WebAssembly/WASI/blob/main/Proposals.md)：
+WasmEdge 实现了以下 [WASI 提案](https://github.com/WebAssembly/WASI/blob/main/docs/Proposals.md)：
 
 | 提案 | 平台支持 |
 | --- | --- |


### PR DESCRIPTION
## Explanation

This PR fixes  several broken external links in the docs that were resulting in GitHub 404 errors. Previously those links pointed to specific and expired GitHub Action runs and a WASI proposals document that was moved. This is a fix to ensure that users can access the correct installation resources and technical specifications in the English and Chinese versions of the documentation.

## Related issue

Closes #289 

## What type of PR is this

/kind documentation

## Proposed Changes

* Updated the link for WASI proposals from `Proposals.md` to `docs/Proposals.md` in the `WebAssembly/WASI` repository.
* Replaced direct links to expired GitHub Action runs with a stable link to the `release.yml` workflow run page in the `WasmEdge/WasmEdge` repository to prevent future 404s.
* Applied these updates to the English and Chinese versions of the "Install", "Proposals", and "Build from Source" documentation pages.
