### PR TITLE
docs: fix broken GitHub links in seL4 documentation

### DIFF
--- a/docs/contribute/source/os/sel4.md
+++ b/docs/contribute/source/os/sel4.md
@@ -36,7 +36,7 @@ $ docker run --rm -v $(pwd):/app -it wasmedge/sel4_build
 
 <!-- prettier-ignore -->
 :::note
-If you do not want to build the seL4 system simulator yourself, you can download the [build artifact](https://github.com/second-state/wasmedge-seL4/actions/runs/1374510169) from our GitHub Actions, and skip directly to [Boot wasmedge-seL4](#boot-wasmedge-sel4)
+If you do not want to build the seL4 system simulator yourself, you can download the [build artifact](https://github.com/second-state/wasmedge-seL4/releases) from our GitHub Actions, and skip directly to [Boot wasmedge-seL4](#boot-wasmedge-sel4)
 :::
 
 ### Automatic installation: all-in-one script

--- a/i18n/zh/docusaurus-plugin-content-docs/current/contribute/source/os/sel4.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/contribute/source/os/sel4.md
@@ -4,7 +4,7 @@ sidebar_position: 8
 
 # Build on seL4 RTOS
 
-[Video demo](https://youtu.be/2Qu-Trtkspk) | [Build logs](https://github.com/second-state/wasmedge-seL4/runs/3982081148?check_suite_focus=true) | [Build artifact](https://github.com/second-state/wasmedge-seL4/actions/runs/1374510169)
+[Video demo](https://youtu.be/2Qu-Trtkspk) | [Build logs](https://github.com/second-state/wasmedge-seL4/actions) | [Build artifact](https://github.com/second-state/wasmedge-seL4/releases)
 
 In this article, we demonstrate how to run WasmEdge on the seL4 RTOS, there are two parts:
 


### PR DESCRIPTION
## Explanation

This PR fixes broken external links in the seL4 documentation that were leading to GitHub 404 errors. These links were previously pointing to specific GitHub Action runs which have since expired. This is a fix that ensures users can consistently access build logs and pre-built artifacts by pointing them to stable, non-expiring resources in both the English and Chinese documentation.

## Related issue : #302

## What type of PR is this

/kind documentation

## Proposed Changes

* Updated `docs/contribute/source/os/sel4.md` to replace expired GitHub Action run IDs with stable links to the repository's Actions overview and official Releases page.
* Applied the same updates to the Chinese translation file `i18n/zh/docusaurus-plugin-content-docs/current/contribute/source/os/sel4.md` to ensure parity.
